### PR TITLE
Bug fix: Checks that scoreThresholds are actually different in ngOnChanges

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conversationai/perspectiveapi-authorship-demo",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "license": "Apache-2.0",
   "scripts": {
     "ng": "ng",

--- a/src/app/perspective-status.component.ts
+++ b/src/app/perspective-status.component.ts
@@ -236,13 +236,26 @@ export class PerspectiveStatus implements OnChanges, AfterViewInit, AfterViewChe
 
     if (changes['scoreThresholds'] !== undefined) {
       console.debug('Change in scoreThresholds');
-      // Kill any prior animations so that the resetting any animation state
-      // will not get overridden by the old animation before the new one can
-      // begin; this can lead to bugs.
-      if (this.updateDemoSettingsAnimation) {
-        this.updateDemoSettingsAnimation.kill();
+      // ngOnChanges will be called for a change in the array reference, not the
+      // array values, so check to make sure they're really different.
+      let valuesChanged = false;
+      let scoreThresholdChanges = changes['scoreThresholds'];
+      for (let i = 0; i < scoreThresholdChanges.previousValue.length; i++) {
+        if (scoreThresholdChanges.currentValue[i]
+            !== scoreThresholdChanges.previousValue[i]) {
+          valuesChanged = true;
+        }
       }
-      this.scoreThresholdsChanged = true;
+
+      if (valuesChanged) {
+        // Kill any prior animations so that the resetting any animation state
+        // will not get overridden by the old animation before the new one can
+        // begin; this can lead to bugs.
+        if (this.updateDemoSettingsAnimation) {
+          this.updateDemoSettingsAnimation.kill();
+        }
+        this.scoreThresholdsChanged = true;
+      }
     }
 
     if (changes['hideLoadingIconAfterLoad']) {

--- a/src/app/perspective-status.component.ts
+++ b/src/app/perspective-status.component.ts
@@ -217,7 +217,7 @@ export class PerspectiveStatus implements OnChanges, AfterViewInit, AfterViewChe
     }
 
     if (changes['loadingIconStyle'] !== undefined) {
-      console.log('Loading icon style change:', changes['loadingIconStyle']);
+      console.debug('Loading icon style change:', changes['loadingIconStyle']);
       this.loadingIconStyleChanged = true;
     }
 
@@ -244,6 +244,7 @@ export class PerspectiveStatus implements OnChanges, AfterViewInit, AfterViewChe
         if (scoreThresholdChanges.currentValue[i]
             !== scoreThresholdChanges.previousValue[i]) {
           valuesChanged = true;
+          break;
         }
       }
 
@@ -711,7 +712,7 @@ export class PerspectiveStatus implements OnChanges, AfterViewInit, AfterViewChe
       let updateScoreCompletedTimeline = new TimelineMax({
         onComplete: () => {
           this.ngZone.run(() => {
-            console.log(this.scoreChangeAnimationCompleted);
+            console.debug(this.scoreChangeAnimationCompleted);
             // TODO(rachelrosen): Debug ObjectUnsubscribedError that occurs here.
             // Seems to happen when animation finishes after changing from emoji
             // to shape. This only happens when this component is a child of the


### PR DESCRIPTION
This check is needed because data binding checks for the array reference change and not the value changes in the array. Needed as part of a fix to https://github.com/Jigsaw-Code/conversationai-website/issues/745