### PR TITLE
Fixes the bug where the widget visibility wasn't correct after loading for alwaysHideLoadingIcon = true

### DIFF
--- a/src/app/convai-checker.component.spec.ts
+++ b/src/app/convai-checker.component.spec.ts
@@ -162,13 +162,6 @@ let getIsElementWithIdVisible = function(id: string): boolean {
       && getElementOpacity(id) > 0;
 }
 
-let getIsElementWithIdPresentButWithZeroOpacity = function(id: string): boolean {
-  let element = document.getElementById(id);
-  return element != null && element.offsetWidth > 0 && element.offsetHeight > 0
-      && window.getComputedStyle(element).display !== 'none'
-      && parseInt(window.getComputedStyle(element).getPropertyValue("opacity"), 10) === 0;
-}
-
 let getElementXTranslation = function(id: string): number|null {
   let element = document.getElementById(id);
   if (!element) {

--- a/src/app/convai-checker.component.spec.ts
+++ b/src/app/convai-checker.component.spec.ts
@@ -347,7 +347,6 @@ describe('Convai checker test', () => {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
   });
 
-  /*
   it('should recognize inputs from attributes', async(() => {
     let fixture = TestBed.createComponent(
       ConvaiCheckerWithAttributeInputTestComponent);
@@ -1892,15 +1891,13 @@ describe('Convai checker test', () => {
     // Send an input event to trigger the service call.
     setTextAndFireInputEvent(queryTexts[callCount], textArea);
   }));
-  */
 
-  it('Test loading icon visibility',
+  it('Test loading icon visibility, alwaysHideLoadingIcon = true, min threshold of 0',
      async(() => {
     let fixture = TestBed.createComponent(ConvaiCheckerCustomDemoSettingsTestComponent);
-    console.log('First detect changes');
     fixture.detectChanges();
 
-    // Case 1: Always show feedback, but never show loading icon.
+    // Always show feedback, but never show the loading icon.
     let demoSettings = getCopyOfDefaultDemoSettings();
     demoSettings.scoreThresholds = [0, 0.6, 0.8];
     demoSettings.alwaysHideLoadingIcon = true;
@@ -1923,11 +1920,42 @@ describe('Convai checker test', () => {
       expectedFeedbackTextVisibilitiesAfterLoading);
   }));
 
-  it('Test loading icon visibility 2',
+  it('Test loading icon visibility, alwaysHideLoadingIcon = true, min threshold of 0, emoji icon',
      async(() => {
     let fixture = TestBed.createComponent(ConvaiCheckerCustomDemoSettingsTestComponent);
     fixture.detectChanges();
-    // Case 2: Show feedback above a minimum threshold, but never show loading icon.
+
+    // Always show feedback, but never show the loading icon.
+    let demoSettings = getCopyOfDefaultDemoSettings();
+    demoSettings.scoreThresholds = [0, 0.6, 0.8];
+    demoSettings.alwaysHideLoadingIcon = true;
+    demoSettings.hideLoadingIconAfterLoad = false;
+    demoSettings.hideLoadingIconForScoresBelowMinThreshold = false;
+    demoSettings.loadingIconStyle = LoadingIconStyle.EMOJI;
+
+    let mockResponseScores = [0.6, 0, 0.9];
+    let expectedWidgetVisibilitiesBeforeLoading = [false, false, false];
+    let expectedWidgetVisibilitiesWhileLoading = [false, false, false];
+    let expectedWidgetVisibilitiesAfterLoading = [false, false, false];
+    let expectedFeedbackTextVisibilitiesAfterLoading = [true, true, true];
+    let widgetId = 'emojiStatusWidget';
+
+    verifyWidgetVisibilityForDemoSettings(
+      fixture,
+      demoSettings,
+      mockResponseScores,
+      expectedWidgetVisibilitiesBeforeLoading,
+      expectedWidgetVisibilitiesWhileLoading,
+      expectedWidgetVisibilitiesAfterLoading,
+      expectedFeedbackTextVisibilitiesAfterLoading,
+      widgetId);
+  }));
+
+  it('Test loading icon visibility, alwaysHideLoadingIcon = true, min threshold > 0',
+     async(() => {
+    let fixture = TestBed.createComponent(ConvaiCheckerCustomDemoSettingsTestComponent);
+    fixture.detectChanges();
+    // Show feedback above a minimum threshold, but never show the loading icon.
     let demoSettings = getCopyOfDefaultDemoSettings();
     demoSettings.scoreThresholds = [0.4, 0.6, 0.8];
     demoSettings.alwaysHideLoadingIcon = true;
@@ -1938,7 +1966,6 @@ describe('Convai checker test', () => {
     let expectedWidgetVisibilitiesWhileLoading = [false, false, false];
     let expectedWidgetVisibilitiesAfterLoading = [false, false, false];
     let expectedFeedbackTextVisibilitiesAfterLoading = [true, false, true];
-    let widgetId = 'circleSquareDiamondWidget';
 
     verifyWidgetVisibilityForDemoSettings(
       fixture,
@@ -1950,11 +1977,41 @@ describe('Convai checker test', () => {
       expectedFeedbackTextVisibilitiesAfterLoading);
   }));
 
-  it('Test loading icon visibility 3',
+  it('Test loading icon visibility, alwaysHideLoadingIcon = true, min threshold > 0, emoji icon',
      async(() => {
     let fixture = TestBed.createComponent(ConvaiCheckerCustomDemoSettingsTestComponent);
     fixture.detectChanges();
-    // Case 3: Always show feedback, and only show loading icon above the min threshold
+    // Show feedback above a minimum threshold, but never show the loading icon.
+    let demoSettings = getCopyOfDefaultDemoSettings();
+    demoSettings.scoreThresholds = [0.4, 0.6, 0.8];
+    demoSettings.alwaysHideLoadingIcon = true;
+    demoSettings.hideLoadingIconAfterLoad = false;
+    demoSettings.hideLoadingIconForScoresBelowMinThreshold = false;
+    demoSettings.loadingIconStyle = LoadingIconStyle.EMOJI;
+    let mockResponseScores = [0.6, 0, 0.9];
+    let expectedWidgetVisibilitiesBeforeLoading = [false, false, false];
+    let expectedWidgetVisibilitiesWhileLoading = [false, false, false];
+    let expectedWidgetVisibilitiesAfterLoading = [false, false, false];
+    let expectedFeedbackTextVisibilitiesAfterLoading = [true, false, true];
+    let widgetId = 'emojiStatusWidget';
+
+    verifyWidgetVisibilityForDemoSettings(
+      fixture,
+      demoSettings,
+      mockResponseScores,
+      expectedWidgetVisibilitiesBeforeLoading,
+      expectedWidgetVisibilitiesWhileLoading,
+      expectedWidgetVisibilitiesAfterLoading,
+      expectedFeedbackTextVisibilitiesAfterLoading,
+      widgetId);
+  }));
+
+  it('Test loading icon visibility, hideLoadingIconForScoresBelowMinThreshold = true, '
+     +' min threshold = 0',
+     async(() => {
+    let fixture = TestBed.createComponent(ConvaiCheckerCustomDemoSettingsTestComponent);
+    fixture.detectChanges();
+    // Always show feedback, and only show loading icon above the min threshold
     // (Implied that the loading icon should always display).
     let demoSettings = getCopyOfDefaultDemoSettings();
     demoSettings.scoreThresholds = [0, 0.6, 0.8];
@@ -1981,11 +2038,46 @@ describe('Convai checker test', () => {
       expectedFeedbackTextVisibilitiesAfterLoading);
   }));
 
-  it('Test loading icon visibility 4',
+  it('Test loading icon visibility, hideLoadingIconForScoresBelowMinThreshold = true, '
+     +' min threshold = 0, emoji icon',
      async(() => {
     let fixture = TestBed.createComponent(ConvaiCheckerCustomDemoSettingsTestComponent);
     fixture.detectChanges();
-    // Case 4: Show feedback above a minimum threshold, and only show loading
+    // Always show feedback, and only show loading icon above the min threshold
+    // (Implied that the loading icon should always display).
+    let demoSettings = getCopyOfDefaultDemoSettings();
+    demoSettings.scoreThresholds = [0, 0.6, 0.8];
+    demoSettings.alwaysHideLoadingIcon = false;
+    demoSettings.hideLoadingIconAfterLoad = false;
+    demoSettings.hideLoadingIconForScoresBelowMinThreshold = true;
+    demoSettings.loadingIconStyle = LoadingIconStyle.EMOJI;
+    let mockResponseScores = [0.6, 0, 0.9];
+    let expectedWidgetVisibilitiesBeforeLoading = [true, true, true];
+    // TODO(rachelrosen): This reflects the current behavior (loading icon is
+    // invisible during loading when hideLoadingIconForScoresBelowMinThreshold =
+    // true), but is this really the correct behavior?
+    let expectedWidgetVisibilitiesWhileLoading = [false, false, false];
+    let expectedWidgetVisibilitiesAfterLoading = [true, true, true];
+    let expectedFeedbackTextVisibilitiesAfterLoading = [true, true, true];
+    let widgetId = 'emojiStatusWidget';
+
+    verifyWidgetVisibilityForDemoSettings(
+      fixture,
+      demoSettings,
+      mockResponseScores,
+      expectedWidgetVisibilitiesBeforeLoading,
+      expectedWidgetVisibilitiesWhileLoading,
+      expectedWidgetVisibilitiesAfterLoading,
+      expectedFeedbackTextVisibilitiesAfterLoading,
+      widgetId);
+  }));
+
+  it('Test loading icon visibility, hideLoadingIconForScoresBelowMinThreshold = true, '
+     + 'min threshold > 0',
+     async(() => {
+    let fixture = TestBed.createComponent(ConvaiCheckerCustomDemoSettingsTestComponent);
+    fixture.detectChanges();
+    // Show feedback above a minimum threshold, and only show loading
     // icon above the min threshold.
     let demoSettings = getCopyOfDefaultDemoSettings();
     demoSettings.scoreThresholds = [0.4, 0.6, 0.8];
@@ -2016,12 +2108,51 @@ describe('Convai checker test', () => {
       expectedFeedbackTextVisibilitiesAfterLoading);
   }));
 
-  it('Test loading icon visibility 5',
+  it('Test loading icon visibility, hideLoadingIconForScoresBelowMinThreshold = true, '
+     + 'min threshold > 0, emoji icon',
+     async(() => {
+    let fixture = TestBed.createComponent(ConvaiCheckerCustomDemoSettingsTestComponent);
+    fixture.detectChanges();
+    // Show feedback above a minimum threshold, and only show loading
+    // icon above the min threshold.
+    let demoSettings = getCopyOfDefaultDemoSettings();
+    demoSettings.scoreThresholds = [0.4, 0.6, 0.8];
+    demoSettings.alwaysHideLoadingIcon = false;
+    demoSettings.hideLoadingIconAfterLoad = false;
+    demoSettings.hideLoadingIconForScoresBelowMinThreshold = true;
+    demoSettings.loadingIconStyle = LoadingIconStyle.EMOJI;
+
+    let mockResponseScores = [0.6, 0, 0.9];
+    let expectedWidgetVisibilitiesBeforeLoading = [
+      false, // The default score is 0, so at the start it will be hidden.
+      true,
+      false
+    ];
+    // TODO(rachelrosen): This reflects the current behavior (loading icon is
+    // invisible during loading when hideLoadingIconForScoresBelowMinThreshold =
+    // true), but is this really the correct behavior?
+    let expectedWidgetVisibilitiesWhileLoading = [false, false, false];
+    let expectedWidgetVisibilitiesAfterLoading = [true, false, true];
+    let expectedFeedbackTextVisibilitiesAfterLoading = [true, false, true];
+    let widgetId = 'emojiStatusWidget';
+
+    verifyWidgetVisibilityForDemoSettings(
+      fixture,
+      demoSettings,
+      mockResponseScores,
+      expectedWidgetVisibilitiesBeforeLoading,
+      expectedWidgetVisibilitiesWhileLoading,
+      expectedWidgetVisibilitiesAfterLoading,
+      expectedFeedbackTextVisibilitiesAfterLoading,
+      widgetId);
+  }));
+
+  it('Test loading icon visibility, hideLoadingIconAfterLoad = true, min threshold = 0',
      async(() => {
     let fixture = TestBed.createComponent(ConvaiCheckerCustomDemoSettingsTestComponent);
     fixture.detectChanges();
 
-    // Case 5: Always show feedback, but hide the loading icon after load.
+    // Always show feedback, but hide the loading icon after load.
     let demoSettings = getCopyOfDefaultDemoSettings();
     demoSettings.scoreThresholds = [0, 0.6, 0.8];
     demoSettings.alwaysHideLoadingIcon = false;
@@ -2043,11 +2174,41 @@ describe('Convai checker test', () => {
       expectedFeedbackTextVisibilitiesAfterLoading);
   }));
 
-  it('Test loading icon visibility 6',
+  it('Test loading icon visibility, hideLoadingIconAfterLoad = true, min threshold = 0, emoji icon',
      async(() => {
     let fixture = TestBed.createComponent(ConvaiCheckerCustomDemoSettingsTestComponent);
     fixture.detectChanges();
-    // Case 6: Show feedback above a minimum threshold, and hide the loading
+
+    // Always show feedback, but hide the loading icon after load.
+    let demoSettings = getCopyOfDefaultDemoSettings();
+    demoSettings.scoreThresholds = [0, 0.6, 0.8];
+    demoSettings.alwaysHideLoadingIcon = false;
+    demoSettings.hideLoadingIconAfterLoad = true;
+    demoSettings.hideLoadingIconForScoresBelowMinThreshold = false;
+    demoSettings.loadingIconStyle = LoadingIconStyle.EMOJI;
+    let mockResponseScores = [0.6, 0, 0.9];
+    let expectedWidgetVisibilitiesBeforeLoading = [false, false, false];
+    let expectedWidgetVisibilitiesWhileLoading = [true, true, true];
+    let expectedWidgetVisibilitiesAfterLoading = [false, false, false];
+    let expectedFeedbackTextVisibilitiesAfterLoading = [true, true, true];
+    let widgetId = 'emojiStatusWidget';
+
+    verifyWidgetVisibilityForDemoSettings(
+      fixture,
+      demoSettings,
+      mockResponseScores,
+      expectedWidgetVisibilitiesBeforeLoading,
+      expectedWidgetVisibilitiesWhileLoading,
+      expectedWidgetVisibilitiesAfterLoading,
+      expectedFeedbackTextVisibilitiesAfterLoading,
+      widgetId);
+  }));
+
+  it('Test loading icon visibility, hideLoadingIconAfterLoad = true, min threshold > 0',
+     async(() => {
+    let fixture = TestBed.createComponent(ConvaiCheckerCustomDemoSettingsTestComponent);
+    fixture.detectChanges();
+    // Show feedback above a minimum threshold, and hide the loading
     // icon after load.
     let demoSettings = getCopyOfDefaultDemoSettings();
     demoSettings.scoreThresholds = [0.4, 0.6, 0.8];
@@ -2071,11 +2232,43 @@ describe('Convai checker test', () => {
       expectedFeedbackTextVisibilitiesAfterLoading);
   }));
 
-  it('Test loading icon visibility 7',
+  it('Test loading icon visibility, hideLoadingIconAfterLoad = true, min threshold > 0, emoji icon',
      async(() => {
     let fixture = TestBed.createComponent(ConvaiCheckerCustomDemoSettingsTestComponent);
     fixture.detectChanges();
-    // Case 7: Show feedback above a minimum threshold, hide the loading icon
+    // Show feedback above a minimum threshold, and hide the loading
+    // icon after load.
+    let demoSettings = getCopyOfDefaultDemoSettings();
+    demoSettings.scoreThresholds = [0.4, 0.6, 0.8];
+    demoSettings.alwaysHideLoadingIcon = false;
+    demoSettings.hideLoadingIconAfterLoad = true;
+    demoSettings.hideLoadingIconForScoresBelowMinThreshold = false;
+    demoSettings.loadingIconStyle = LoadingIconStyle.EMOJI;
+
+    let mockResponseScores = [0.6, 0, 0.9];
+    let expectedWidgetVisibilitiesBeforeLoading = [false, false, false];
+    let expectedWidgetVisibilitiesWhileLoading = [true, true, true];
+    let expectedWidgetVisibilitiesAfterLoading = [false, false, false];
+    let expectedFeedbackTextVisibilitiesAfterLoading = [true, false, true];
+    let widgetId = 'emojiStatusWidget';
+
+    verifyWidgetVisibilityForDemoSettings(
+      fixture,
+      demoSettings,
+      mockResponseScores,
+      expectedWidgetVisibilitiesBeforeLoading,
+      expectedWidgetVisibilitiesWhileLoading,
+      expectedWidgetVisibilitiesAfterLoading,
+      expectedFeedbackTextVisibilitiesAfterLoading,
+      widgetId);
+  }));
+
+  it('Test loading icon visibility, hideLoadingIconAfterLoad = true, '
+     + 'hideLoadingIconForScoresBelowMinThreshold = true, min threshold > 0',
+     async(() => {
+    let fixture = TestBed.createComponent(ConvaiCheckerCustomDemoSettingsTestComponent);
+    fixture.detectChanges();
+    // Show feedback above a minimum threshold, hide the loading icon
     // after loading completes, and hide the loading icon for scores below the
     // minimum threshold. (hideLoadingIconAfterLoad should override
     // hideLoadingIconForScoresBelowMinThreshold).
@@ -2104,11 +2297,50 @@ describe('Convai checker test', () => {
       expectedFeedbackTextVisibilitiesAfterLoading);
   }));
 
-  it('Test loading icon visibility 8',
+  it('Test loading icon visibility, hideLoadingIconAfterLoad = true, '
+     + 'hideLoadingIconForScoresBelowMinThreshold = true, min threshold > 0 '
+     + 'emoji icon',
      async(() => {
     let fixture = TestBed.createComponent(ConvaiCheckerCustomDemoSettingsTestComponent);
     fixture.detectChanges();
-    // Case 8: Show feedback above a minimum threshold, hide the loading icon
+    // Show feedback above a minimum threshold, hide the loading icon
+    // after loading completes, and hide the loading icon for scores below the
+    // minimum threshold. (hideLoadingIconAfterLoad should override
+    // hideLoadingIconForScoresBelowMinThreshold).
+    let demoSettings = getCopyOfDefaultDemoSettings();
+    demoSettings.scoreThresholds = [0.4, 0.6, 0.8];
+    demoSettings.alwaysHideLoadingIcon = false;
+    demoSettings.hideLoadingIconAfterLoad = true;
+    demoSettings.hideLoadingIconForScoresBelowMinThreshold = true;
+    demoSettings.loadingIconStyle = LoadingIconStyle.EMOJI;
+
+    let mockResponseScores = [0.6, 0, 0.9];
+    let expectedWidgetVisibilitiesBeforeLoading = [false, false, false];
+    // TODO(rachelrosen): This reflects the current behavior (loading icon is
+    // invisible during loading when hideLoadingIconForScoresBelowMinThreshold =
+    // true), but is this really the correct behavior?
+    let expectedWidgetVisibilitiesWhileLoading = [false, false, false];
+    let expectedWidgetVisibilitiesAfterLoading = [false, false, false];
+    let expectedFeedbackTextVisibilitiesAfterLoading = [true, false, true];
+    let widgetId = 'emojiStatusWidget';
+
+    verifyWidgetVisibilityForDemoSettings(
+      fixture,
+      demoSettings,
+      mockResponseScores,
+      expectedWidgetVisibilitiesBeforeLoading,
+      expectedWidgetVisibilitiesWhileLoading,
+      expectedWidgetVisibilitiesAfterLoading,
+      expectedFeedbackTextVisibilitiesAfterLoading,
+      widgetId);
+  }));
+
+  it('Test loading icon visibility, alwaysHideLoadingIcon = true, '
+     + ' hideLoadingIconAfterLoad = true, min threshold > 0',
+     async(() => {
+    let fixture = TestBed.createComponent(ConvaiCheckerCustomDemoSettingsTestComponent);
+    fixture.detectChanges();
+    // Show feedback above a minimum threshold, hide the loading icon
     // after loading completes, and always hide the loading icon.
     // (alwaysHideLoadingIcon should override hideLoadingIconAfterLoad).
     let demoSettings = getCopyOfDefaultDemoSettings();
@@ -2130,14 +2362,47 @@ describe('Convai checker test', () => {
       expectedWidgetVisibilitiesWhileLoading,
       expectedWidgetVisibilitiesAfterLoading,
       expectedFeedbackTextVisibilitiesAfterLoading);
-
   }));
 
-  it('Test loading icon visibility 9',
+  it('Test loading icon visibility, alwaysHideLoadingIcon = true, '
+     + ' hideLoadingIconAfterLoad = true, min threshold > 0, emoji icon',
      async(() => {
     let fixture = TestBed.createComponent(ConvaiCheckerCustomDemoSettingsTestComponent);
     fixture.detectChanges();
-    // Case 9: Show feedback above a minimum threshold, hide the loading icon
+    // Show feedback above a minimum threshold, hide the loading icon
+    // after loading completes, and always hide the loading icon.
+    // (alwaysHideLoadingIcon should override hideLoadingIconAfterLoad).
+    let demoSettings = getCopyOfDefaultDemoSettings();
+    demoSettings.scoreThresholds = [0.4, 0.6, 0.8];
+    demoSettings.alwaysHideLoadingIcon = true;
+    demoSettings.hideLoadingIconAfterLoad = true;
+    demoSettings.hideLoadingIconForScoresBelowMinThreshold = false;
+    demoSettings.loadingIconStyle = LoadingIconStyle.EMOJI;
+    let mockResponseScores = [0.6, 0, 0.9];
+    let expectedWidgetVisibilitiesBeforeLoading = [false, false, false];
+    let expectedWidgetVisibilitiesWhileLoading = [false, false, false];
+    let expectedWidgetVisibilitiesAfterLoading = [false, false, false];
+    let expectedFeedbackTextVisibilitiesAfterLoading = [true, false, true];
+    let widgetId = 'emojiStatusWidget';
+
+    verifyWidgetVisibilityForDemoSettings(
+      fixture,
+      demoSettings,
+      mockResponseScores,
+      expectedWidgetVisibilitiesBeforeLoading,
+      expectedWidgetVisibilitiesWhileLoading,
+      expectedWidgetVisibilitiesAfterLoading,
+      expectedFeedbackTextVisibilitiesAfterLoading,
+      widgetId);
+
+  }));
+
+  it('Test loading icon visibility, alwaysHideLoadingIcon = true, hideLoadingIconAfterLoad = true, '
+     + 'and hideLoadingIconForScoresBelowMinThreshold = true, min threshold > 0',
+     async(() => {
+    let fixture = TestBed.createComponent(ConvaiCheckerCustomDemoSettingsTestComponent);
+    fixture.detectChanges();
+    // Show feedback above a minimum threshold, hide the loading icon
     // after loading completes, hide the loading icon for scores below the
     // minimum threshold, and always hide the loading icon.
     // (alwaysHideLoadingIcon should override hideLoadingIconAfterLoad and
@@ -2163,9 +2428,47 @@ describe('Convai checker test', () => {
       expectedFeedbackTextVisibilitiesAfterLoading);
   }));
 
-  // TODO: Add checks for x position if possible, and check that feedback is
-  // still displayed where appropriate.
-  // Note: Only one MockConnection can be 
+  it('Test loading icon visibility, alwaysHideLoadingIcon = true, hideLoadingIconAfterLoad = true, '
+     + 'and hideLoadingIconForScoresBelowMinThreshold = true, min threshold > 0, emoji icon',
+     async(() => {
+    let fixture = TestBed.createComponent(ConvaiCheckerCustomDemoSettingsTestComponent);
+    fixture.detectChanges();
+    // Show feedback above a minimum threshold, hide the loading icon
+    // after loading completes, hide the loading icon for scores below the
+    // minimum threshold, and always hide the loading icon.
+    // (alwaysHideLoadingIcon should override hideLoadingIconAfterLoad and
+    // hideLoadingIconForScoresBelowMinThreshold).
+    let demoSettings = getCopyOfDefaultDemoSettings();
+    demoSettings.scoreThresholds = [0.4, 0.6, 0.8];
+    demoSettings.alwaysHideLoadingIcon = true;
+    demoSettings.hideLoadingIconAfterLoad = true;
+    demoSettings.hideLoadingIconForScoresBelowMinThreshold = true;
+    demoSettings.loadingIconStyle = LoadingIconStyle.EMOJI;
+    let mockResponseScores = [0.6, 0, 0.9];
+    let expectedWidgetVisibilitiesBeforeLoading = [false, false, false];
+    let expectedWidgetVisibilitiesWhileLoading = [false, false, false];
+    let expectedWidgetVisibilitiesAfterLoading = [false, false, false];
+    let expectedFeedbackTextVisibilitiesAfterLoading = [true, false, true];
+    let widgetId = 'emojiStatusWidget';
+
+    verifyWidgetVisibilityForDemoSettings(
+      fixture,
+      demoSettings,
+      mockResponseScores,
+      expectedWidgetVisibilitiesBeforeLoading,
+      expectedWidgetVisibilitiesWhileLoading,
+      expectedWidgetVisibilitiesAfterLoading,
+      expectedFeedbackTextVisibilitiesAfterLoading,
+      widgetId);
+  }));
+
+
+  // Checks that the loading icon/widget visibility and feedback visibility are
+  // correct given the settings.
+  //
+  // TODO(rachelrosen): If this function is called more than once from within an
+  // individual test, we get an error: "Connection has already been resolved."
+  // Investigate why.
   function verifyWidgetVisibilityForDemoSettings(
       fixture: ComponentFixture<ConvaiCheckerCustomDemoSettingsTestComponent>,
       demoSettings: DemoSettings,

--- a/src/app/convai-checker.component.spec.ts
+++ b/src/app/convai-checker.component.spec.ts
@@ -319,6 +319,7 @@ describe('Convai checker test', () => {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
   });
 
+  /*
   it('should recognize inputs from attributes', async(() => {
     let fixture = TestBed.createComponent(
       ConvaiCheckerWithAttributeInputTestComponent);
@@ -1858,4 +1859,187 @@ describe('Convai checker test', () => {
     // Send an input event to trigger the service call.
     setTextAndFireInputEvent(queryTexts[callCount], textArea);
   }));
+  */
+
+
+  it('Test loading icon visibility',
+     async(() => {
+    let fixture = TestBed.createComponent(ConvaiCheckerCustomDemoSettingsTestComponent);
+    fixture.detectChanges();
+
+    // Case 1: Always show feedback, but never show loading icon.
+    let demoSettings = getCopyOfDefaultDemoSettings();
+    demoSettings.scoreThresholds = [0, 0.6, 0.8];
+    demoSettings.alwaysHideLoadingIcon = true;
+    demoSettings.hideLoadingIconAfterLoad = false;
+    demoSettings.hideLoadingIconForScoresBelowMinThreshold = false;
+
+    let mockResponseScores = [0.6, 0, 0.9];
+    let expectedWidgetVisibilitiesBeforeLoading = [false, false, false];
+    let expectedWidgetVisibilitiesWhileLoading = [false, false, false];
+    let expectedWidgetVisibilitiesAfterLoading = [false, false, false];
+    let widgetId = 'circleSquareDiamondWidget';
+
+    verifyWidgetVisibilityForDemoSettings(
+      fixture,
+      demoSettings,
+      mockResponseScores,
+      expectedWidgetVisibilitiesBeforeLoading,
+      expectedWidgetVisibilitiesWhileLoading,
+      expectedWidgetVisibilitiesAfterLoading,
+      widgetId);
+  /*
+    // Case 2: Show feedback above a minimum threshold, but never show loading icon.
+    let demoSettings = getCopyOfDefaultDemoSettings();
+    demoSettings.scoreThresholds = [0.4, 0.6, 0.8];
+    demoSettings.alwaysHideLoadingIcon = true;
+    demoSettings.hideLoadingIconAfterLoad = false;
+    demoSettings.hideLoadingIconForScoresBelowMinThreshold = false;
+
+    // Case 3: Always show feedback, and only show loading icon above the min threshold
+    // (Implied that the loading icon should always display).
+    let demoSettings = getCopyOfDefaultDemoSettings();
+    demoSettings.scoreThresholds = [0, 0.6, 0.8];
+    demoSettings.alwaysHideLoadingIcon = false;
+    demoSettings.hideLoadingIconAfterLoad = false;
+    demoSettings.hideLoadingIconForScoresBelowMinThreshold = true;
+
+    // Case 4: Show feedback above a minimum threshold, and only show loading
+    // icon above the min threshold.
+    let demoSettings = getCopyOfDefaultDemoSettings();
+    demoSettings.scoreThresholds = [0.4, 0.6, 0.8];
+    demoSettings.alwaysHideLoadingIcon = false;
+    demoSettings.hideLoadingIconAfterLoad = false;
+    demoSettings.hideLoadingIconForScoresBelowMinThreshold = true;
+
+    // Case 5: Always show feedback, but hide the loading icon after load.
+    let demoSettings = getCopyOfDefaultDemoSettings();
+    demoSettings.scoreThresholds = [0, 0.6, 0.8];
+    demoSettings.alwaysHideLoadingIcon = false;
+    demoSettings.hideLoadingIconAfterLoad = true;
+    demoSettings.hideLoadingIconForScoresBelowMinThreshold = false;
+
+    // Case 6: Show feedback above a minimum threshold, and hide the loading
+    // icon after load.
+    let demoSettings = getCopyOfDefaultDemoSettings();
+    demoSettings.scoreThresholds = [0.4, 0.6, 0.8];
+    demoSettings.alwaysHideLoadingIcon = false;
+    demoSettings.hideLoadingIconAfterLoad = true;
+    demoSettings.hideLoadingIconForScoresBelowMinThreshold = false;
+
+    // Case 7: Show feedback above a minimum threshold, hide the loading icon
+    // after loading completes, and hide the loading icon for scores below the
+    // minimum threshold. (hideLoadingIconAfterLoad should override
+    // hideLoadingIconForScoresBelowMinThreshold).
+    let demoSettings = getCopyOfDefaultDemoSettings();
+    demoSettings.scoreThresholds = [0.4, 0.6, 0.8];
+    demoSettings.alwaysHideLoadingIcon = false;
+    demoSettings.hideLoadingIconAfterLoad = true;
+    demoSettings.hideLoadingIconForScoresBelowMinThreshold = true;
+
+    // Case 8: Show feedback above a minimum threshold, hide the loading icon
+    // after loading completes, and always hide the loading icon.
+    // (alwaysHideLoadingIcon should override hideLoadingIconAfterLoad).
+    let demoSettings = getCopyOfDefaultDemoSettings();
+    demoSettings.scoreThresholds = [0.4, 0.6, 0.8];
+    demoSettings.alwaysHideLoadingIcon = true;
+    demoSettings.hideLoadingIconAfterLoad = true;
+    demoSettings.hideLoadingIconForScoresBelowMinThreshold = false;
+
+    // Case 9: Show feedback above a minimum threshold, hide the loading icon
+    // after loading completes, hide the loading icon for scores below the
+    // minimum threshold, and always hide the loading icon.
+    // (alwaysHideLoadingIcon should override hideLoadingIconAfterLoad and
+    // hideLoadingIconForScoresBelowMinThreshold).
+    let demoSettings = getCopyOfDefaultDemoSettings();
+    demoSettings.scoreThresholds = [0.4, 0.6, 0.8];
+    demoSettings.alwaysHideLoadingIcon = true;
+    demoSettings.hideLoadingIconAfterLoad = true;
+    demoSettings.hideLoadingIconForScoresBelowMinThreshold = true;
+     *
+     */
+
+  }));
+
+
+  // TODO: Add checks for x position if possible, and check that feedback is
+  // still displayed where appropriate.
+  function verifyWidgetVisibilityForDemoSettings(
+      fixture: ComponentFixture<ConvaiCheckerCustomDemoSettingsTestComponent>,
+      demoSettings: DemoSettings,
+      mockResponseScores: number[],
+      expectedWidgetVisibilitiesBeforeLoading: boolean[],
+      expectedWidgetVisibilitiesWhileLoading: boolean[],
+      expectedWidgetVisibilitiesAfterLoading: boolean[],
+      widgetId: string) {
+    let checker = fixture.componentInstance.checker;
+    let textArea = fixture.debugElement.query(
+      By.css('#' + checker.inputId)).nativeElement;
+
+    // Set up the mock responses for the series of three requests that will be
+    // made in the test.
+    let queryTexts = [
+      'Your mother was a hamster',
+      'Your father smelled of elderberries',
+      'What is the air velocity of an unladen swallow?'
+    ];
+
+    let mockResponses = [
+      getMockCheckerResponseWithScore(mockResponseScores[0], checker.getToken(queryTexts[0])),
+      getMockCheckerResponseWithScore(mockResponseScores[1], checker.getToken(queryTexts[1])),
+      getMockCheckerResponseWithScore(mockResponseScores[2], checker.getToken(queryTexts[2]))
+    ];
+
+    let mockBackend = TestBed.get(MockBackend);
+    mockBackend.connections
+     .subscribe((connection: MockConnection) => {
+       fixture.detectChanges();
+       // Check the UI state before returning the repsonse.
+       expect(checker.statusWidget.isLoading).toBe(true);
+       expect(getIsElementWithIdVisible(widgetId))
+         .toBe(expectedWidgetVisibilitiesWhileLoading[callCount]);
+       connection.mockRespond(
+         new Response(
+           new ResponseOptions({
+              body: mockResponses[callCount]
+           })
+         )
+       );
+
+       // Wait for async code to complete.
+       fixture.whenStable().then(() => {
+         fixture.detectChanges();
+         // Checks the UI state after the response has been received.
+
+         // Checks that loading has stopped.
+         expect(checker.statusWidget.isLoading).toBe(false);
+         expect(getIsElementWithIdVisible(widgetId))
+           .toBe(expectedWidgetVisibilitiesAfterLoading[callCount]);
+
+         if (callCount < mockResponses.length - 1) {
+           callCount++;
+           // Check visibility before loading.
+           expect(getIsElementWithIdVisible(widgetId))
+              .toBe(expectedWidgetVisibilitiesBeforeLoading[callCount]);
+           // Fire another request.
+           setTextAndFireInputEvent(queryTexts[callCount], textArea);
+         }
+       });
+     });
+
+    // Test steps:
+    // 1. Update settings
+    fixture.componentInstance.setDemoSettings(demoSettings);
+    fixture.detectChanges();
+
+    // 2. Check initial visibility  (default circleSquareDiamondWidget)
+    let callCount = 0;
+    expect(getIsElementWithIdVisible(widgetId))
+      .toBe(expectedWidgetVisibilitiesBeforeLoading[callCount]);
+
+    // 3. Run query and check visibility.
+    // Send an input event to trigger the service call.
+    setTextAndFireInputEvent(queryTexts[callCount], textArea);
+  }
+
 });

--- a/src/app/customizable-demo-form.component.html
+++ b/src/app/customizable-demo-form.component.html
@@ -182,6 +182,13 @@
                        (change)="onSettingsChanged()">Hide loading icon after load
       </mat-slide-toggle>
     </div>
+  
+    <div class="setting">
+      <mat-slide-toggle [(ngModel)]="alwaysHideLoadingIcon"
+        (change)="onSettingsChanged()">Always hide the loading icon.
+      </mat-slide-toggle>
+    </div>
+
 
     <div class="setting">
       <mat-slide-toggle [(ngModel)]="hideLoadingIconForScoresBelowMinThreshold"

--- a/src/app/perspective-status.component.html
+++ b/src/app/perspective-status.component.html
@@ -47,7 +47,7 @@
                                  'layer': true,
                                  'hiddenLayer': !layersAnimating && currentLayerIndex !== 0}"
                      [attr.aria-hidden]="currentLayerIndex !== 0">
-      <div class="layerText">
+      <div id="layerText" class="layerText">
         <!-- For layer 1 text, configurations EXTERNAL and DEMO_SITE are the same.-->
         <div>
           <div id="noBorderButtonscoreInfo"

--- a/src/app/perspective-status.component.ts
+++ b/src/app/perspective-status.component.ts
@@ -702,6 +702,17 @@ export class PerspectiveStatus implements OnChanges, AfterViewInit, AfterViewChe
     }
   }
 
+  // Gets the emoji corresponding to the specified score.
+  getEmojiForScore(score: number): Emoji {
+    if (score > this.scoreThresholds[2]) {
+      return Emoji.SAD;
+    } else if (score > this.scoreThresholds[1]) {
+      return Emoji.NEUTRAL;
+    } else {
+      return Emoji.SMILE;
+    }
+  }
+
   getUpdateShapeAnimation(score: number): TimelineMax {
     if (this.loadingIconStyle !== LoadingIconStyle.CIRCLE_SQUARE_DIAMOND) {
       console.debug('Calling getUpdateShapeAnimation(), but the loading icon'
@@ -950,6 +961,12 @@ export class PerspectiveStatus implements OnChanges, AfterViewInit, AfterViewChe
       loadingStartTimeline.add(
         this.getTransitionToLayerAnimation(0, LAYER_TRANSITION_TIME_SECONDS));
     }
+    // Update visibility of the emoji icon before starting; it could have
+    // disappeared due to certain settings, and in some of these cases it
+    // needs to reappear before loading animation begins.
+    loadingStartTimeline.add(
+      this.getUpdateStatusWidgetVisibilityAnimation(true));
+
     loadingStartTimeline.add(
       this.getFadeDetailsAnimation(FADE_DETAILS_TIME_SECONDS, true, 0));
     loadingStartTimeline.add([
@@ -975,20 +992,53 @@ export class PerspectiveStatus implements OnChanges, AfterViewInit, AfterViewChe
   }
 
   /** Loading animations to play when loading finishes for emoji-style loading. */
-  getEndAnimationsForEmojiWidgetLoading(): TimelineMax {
+  getEndAnimationsForEmojiWidgetLoading(loadingTimeline: TimelineMax): TimelineMax {
     let loadingEndTimeline = new TimelineMax({
       onComplete: () => {
         this.ngZone.run(()=> {
           console.debug('Setting this.isPlayingLoadingAnimation = false (emoji)');
           this.isPlayingLoadingAnimation = false;
+          loadingTimeline.clear();
+          this.scoreChangeAnimationCompleted.emit();
+          if (this.isLoading) {
+            // If we finish the end loading animation and we're supposed
+            // to be loading again, restart the loading animation!
+            console.debug('Restarting loading from ending animation completion');
+            this.setLoading(true);
+          } else if (this.currentEmoji !== this.getEmojiForScore(this.score)) {
+            // The score has changed between now and when the animation
+            // started (the emoji is no longer valid).
+            console.debug(
+              'Load ending animation completed, found an out of date shape');
+            this.notifyScoreChange(this.score);
+          }
         });
       }
     });
-    loadingEndTimeline.add(this.getShowEmojiAnimation());
-    loadingEndTimeline.add(
+    let scoreCompletedAnimations: Animation[] = [];
+    scoreCompletedAnimations.push(this.getShowEmojiAnimation());
+    scoreCompletedAnimations.push(
       this.getFadeDetailsAnimation(FADE_DETAILS_TIME_SECONDS, false, 0));
+
+    // If we're revealing the status widget, play the reveal animation
+    // before the update emoji animation.
+    if (!this.getShouldHideStatusWidget(false)) {
+      loadingEndTimeline.add(
+        this.getUpdateStatusWidgetVisibilityAnimation(false));
+    }
+
+    loadingEndTimeline.add(scoreCompletedAnimations);
+
+    // If we're hiding the status widget, play the hide widget
+    // animation after the update emoji animation.
+    if (this.getShouldHideStatusWidget(false)) {
+      loadingEndTimeline.add(
+        this.getUpdateStatusWidgetVisibilityAnimation(false));
+    }
+
     if (this.pendingPostLoadingStateChangeAnimations) {
-      loadingEndTimeline.add(this.pendingPostLoadingStateChangeAnimations);
+      loadingEndTimeline.add(
+        this.pendingPostLoadingStateChangeAnimations);
     }
     return loadingEndTimeline;
   }
@@ -1130,7 +1180,7 @@ export class PerspectiveStatus implements OnChanges, AfterViewInit, AfterViewChe
               console.debug('Restarting main emoji loading animation');
               loadingTimeline.seek(EMOJI_MAIN_LOADING_ANIMATION_LABEL);
             } else {
-              this.getEndAnimationsForEmojiWidgetLoading().play();
+              this.getEndAnimationsForEmojiWidgetLoading(loadingTimeline).play();
             }
           });
         }

--- a/src/app/perspective-status.component.ts
+++ b/src/app/perspective-status.component.ts
@@ -474,6 +474,9 @@ export class PerspectiveStatus implements OnChanges, AfterViewInit, AfterViewChe
     if (this.hideLoadingIconForScoresBelowMinThreshold) {
       shouldHide = shouldHide || loadStart || (this.score < this.scoreThresholds[0]);
     }
+    if (this.alwaysHideLoadingIcon) {
+      shouldHide = true;
+    }
 
     return shouldHide;
   }


### PR DESCRIPTION
This resulted in the bug where there would be a gap between where the widget was and the feedback text (the widget was hidden but the space in the UI was still there), and then the feedback text would animate to the left after loading completed, which is the behavior of a different setting, hideLoadingIconAfterLoad. This change ensures that the loading icon is always hidden when alwaysHideLoadingIcon = true, and that there is no "slide to the left" animation in this case.

Also adds a bunch of tests to validate widget visibility behavior to try and avoid these types of bugs in the future, and fixes a few visibility bugs uncovered with the emoji mode discovered along the way.