### PR TITLE
 Set apiKey from JSON, fix proxy-config

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "ng": "ng",
-    "serve": "npm run setup && ./node_modules/.bin/concurrently \"npm run start:dev-server\" \"ng serve --proxy proxy.conf.json\"",
+    "serve": "npm run setup && ./node_modules/.bin/concurrently \"npm run start:dev-server\" \"ng serve --proxy-config proxy.conf.json\"",
     "start:dev-server": "NODE_ENV=development node node_modules/@conversationai/perspectiveapi-simple-server/build/server/run_server.js build/config/server_config.json",
     "start:prod-server": "NODE_ENV=production node node_modules/@conversationai/perspectiveapi-simple-server/build/server/run_server.js build/config/server_config.json",
     "setup": "mkdir -p build/config/ && rsync --ignore-existing config/server_config.template.json build/config/server_config.json",

--- a/src/app/modules/convai-checker/convai-checker.component.ts
+++ b/src/app/modules/convai-checker/convai-checker.component.ts
@@ -142,7 +142,7 @@ export class ConvaiChecker implements OnInit, OnChanges {
   // a non-Angular context (when convai-checker is being used as a
   // webcomponent). If working from an Angular context, use |demoSettings|.
   @Input() demoSettingsJson: string|null = null;
-  @Input() pluginEndpointUrl = 'http://perspectiveapi.com';
+  @Input() pluginEndpointUrl = 'http://perspectiveapi.com/plugin';
   @Output() scoreChangeAnimationCompleted: EventEmitter<void> = new EventEmitter<void>();
   @Output() scoreChanged: EventEmitter<number> = new EventEmitter<number>();
   @Output() modelInfoLinkClicked: EventEmitter<void> = new EventEmitter<void>();
@@ -189,12 +189,15 @@ export class ConvaiChecker implements OnInit, OnChanges {
       return;
     }
 
-    if (this.apiKey) {
-      this.analyzeApiService.initGapiClient(this.apiKey);
-    }
-
     if (this.demoSettingsJson) {
       this.demoSettings = JSON.parse(this.demoSettingsJson);
+      if (this.demoSettings.apiKey) {
+        this.apiKey = this.demoSettings.apiKey;
+      }
+    }
+
+    if (this.apiKey) {
+      this.analyzeApiService.initGapiClient(this.apiKey);
     }
 
     this.sessionId = window.localStorage.getItem(LOCAL_STORAGE_SESSION_ID_KEY);

--- a/src/app/modules/convai-checker/convai-checker.component.ts
+++ b/src/app/modules/convai-checker/convai-checker.component.ts
@@ -142,7 +142,7 @@ export class ConvaiChecker implements OnInit, OnChanges {
   // a non-Angular context (when convai-checker is being used as a
   // webcomponent). If working from an Angular context, use |demoSettings|.
   @Input() demoSettingsJson: string|null = null;
-  @Input() pluginEndpointUrl = 'http://perspectiveapi.com/plugin';
+  @Input() pluginEndpointUrl = 'http://perspectiveapi.com';
   @Output() scoreChangeAnimationCompleted: EventEmitter<void> = new EventEmitter<void>();
   @Output() scoreChanged: EventEmitter<number> = new EventEmitter<number>();
   @Output() modelInfoLinkClicked: EventEmitter<void> = new EventEmitter<void>();


### PR DESCRIPTION
This change uses the apiKey in the `convai-checker` demoSettingsJson (if available) to initialize the gapi client.

It also fixes the --proxy-config argument for `ng serve`