### PR TITLE
Copies assets into the dist directory to be distributed with npm.

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,23 @@ Run `yarn run packagr` to build the javascript bundles, which will generate a
 `dist/` directory. Then run `npm publish dist` to publish the contents of that
 directory.
 
+### Important note
+
+When using this library in another package, in order to access the image assets
+for emoji mode, you must add the assets from this package to the assets in your
+angular.json:
+
+"assets": [
+   {
+     "glob": "*",
+     "input": "node_modules/@conversationai/perspectiveapi-authorship-demo/src/assets",
+     "output": "./assets"
+   }
+]
+
+See https://github.com/angular/angular-cli/issues/3555#issuecomment-285187411
+and https://github.com/angular/angular-cli/pull/4691 for more info.
+
 ## Notes
 
 This is example code to help experimentation with the Perspective API; it is not an official Google product.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conversationai/perspectiveapi-authorship-demo",
-  "version": "0.6.0",
+  "version": "0.6.3",
   "license": "Apache-2.0",
   "scripts": {
     "ng": "ng",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",
-    "packagr": "ng-packagr -p ng-package.json"
+    "packagr": "ng-packagr -p ng-package.json && cp -r ./src/assets ./dist/src/assets"
   },
   "peerDependencies": {
     "@angular/animations": "6.0.0",


### PR DESCRIPTION
#54 

Not a complete fix, since it still requires projects importing this library to add some config to their angular.json, but this is what the current limitation of angular-cli is.