### PR TITLE
Disables the "learn more" UI for the plugin and adds a custom link for the "toxic" link in the show feedback prompt that directs to our API documentation

### DIFF
--- a/src/app/modules/convai-checker/convai-checker.component.html
+++ b/src/app/modules/convai-checker/convai-checker.component.html
@@ -1,6 +1,11 @@
 <div id="checkerContainer">
   <!-- TODO(rachelrosen): merge perspective-status and convai-checker
-       and move a large portion of the convai-checker code to the perspective-api service. -->
+       and move a large portion of the convai-checker code to the perspective-api service. 
+
+       TODO: We're disabling the "learn more" link for the plugin while we decide what to
+       allow in terms of link customization. Re-enable if we decide we want to allow
+       users to customize the link destination target.
+  -->
   <perspective-status
     [fontSize]="fontSize"
     [indicatorWidth]="13"
@@ -10,7 +15,7 @@
     [feedbackText]="demoSettings.feedbackText"
     [configurationInput]="demoSettings.configuration"
     [showPercentage]="demoSettings.showPercentage"
-    [showMoreInfoLink]="demoSettings.showMoreInfoLink"
+    [showMoreInfoLink]="demoSettings.usePluginEndpoint ? false : demoSettings.showMoreInfoLink"
     [hasScore]="analyzeCommentResponse !== null"
     [canAcceptFeedback]="canAcceptFeedback"
     [feedbackRequestInProgress]="feedbackRequestInProgress"

--- a/src/app/modules/convai-checker/convai-checker.component.ts
+++ b/src/app/modules/convai-checker/convai-checker.component.ts
@@ -121,6 +121,9 @@ export const DEFAULT_DEMO_SETTINGS = {
   userFeedbackPromptText: 'Seem wrong?'
 };
 
+const GITHUB_PAGE_LINK =
+  'https://github.com/conversationai/perspectiveapi/blob/master/api_reference.md#alpha';
+
 @Component({
   selector: 'convai-checker',
   templateUrl: './convai-checker.component.html',
@@ -292,10 +295,21 @@ export class ConvaiChecker implements OnInit, OnChanges {
     console.debug('Score animation completed! Emitting an event');
   }
 
+  /**
+   * This event callback can get triggered in two ways:
+   *   1) when the user clicks "Learn more"
+   *   2) when the user clicks the "toxic" link for the "Is this toxic?"
+   *      feedback question.
+   */
   handleModelInfoLinkClicked() {
     // Allow the output event to bubble up from the child checker-status
     // component through this component.
     this.modelInfoLinkClicked.emit();
+
+    if (this.demoSettings.usePluginEndpoint) {
+      // Open a link to our github page.
+      window.open(GITHUB_PAGE_LINK, '_blank');
+    }
   }
 
   suggestCommentScore(text: string, feedback: CommentFeedback): void {


### PR DESCRIPTION
We may eventually allow customization for the learn more link; added a TODO to address this.

Fixes #74 