### PR TITLE
Updates the demo to use the summaryScore instead of the max over the span scores

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conversationai/perspectiveapi-authorship-demo",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "license": "Apache-2.0",
   "scripts": {
     "ng": "ng",

--- a/src/app/modules/convai-checker/perspectiveapi-types.ts
+++ b/src/app/modules/convai-checker/perspectiveapi-types.ts
@@ -45,7 +45,7 @@ export interface FloatValue {
 }
 
 export interface AnalyzeCommentResponse {
-  attributeScores?: AttributeScores;
+  attributeScores?: AttributeScoresMap;
   languages?: string[];
   clientToken?: string;
 }
@@ -54,7 +54,7 @@ export interface SuggestCommentScoreRequest {
   comment: TextEntry;
   context?: Context;
   languages?: string[];
-  attribute_scores?: AttributeScores;
+  attribute_scores?: AttributeScoresMap;
   community_id?: string;
   user_id?: string;
   client_token?: string;
@@ -82,8 +82,8 @@ export interface SuggestCommentScoreData {
   modelName?: string;
 }
 
-export interface AttributeScores {
- [key: string]: SpanScores;
+export interface AttributeScoresMap {
+ [key: string]: AttributeScores;
 }
 
 export interface SuggestCommentScoreResponse {
@@ -105,7 +105,7 @@ export interface ArticleAndParentComment {
   parent_comment?: TextEntry;
 }
 
-export interface SpanScores {
+export interface AttributeScores {
   spanScores?: SpanScore[];
   summaryScore?: Score;
 }

--- a/src/app/modules/convai-checker/perspectiveapi.service.ts
+++ b/src/app/modules/convai-checker/perspectiveapi.service.ts
@@ -23,7 +23,7 @@ import {
   AnalyzeCommentData,
   AnalyzeCommentRequest,
   AnalyzeCommentResponse,
-  AttributeScores,
+  AttributeScoresMap,
   PerspectiveGapiClient,
   RequestedAttributes,
   SuggestCommentScoreData,
@@ -34,7 +34,7 @@ import {
 // TODO: Make this configurable for dev vs prod.
 const DISCOVERY_URL = 'https://commentanalyzer.googleapis.com/$discovery'
     + '/rest?version=v1alpha1';
-const TOXICITY_ATTRIBUTE = 'TOXICITY';
+export const TOXICITY_ATTRIBUTE = 'TOXICITY';
 
 @Injectable()
 export class PerspectiveApiService {
@@ -109,7 +109,7 @@ export class PerspectiveApiService {
       makeDirectApiCall = false;
     }
     if (makeDirectApiCall) {
-      const attributeScores: AttributeScores  = {};
+      const attributeScores: AttributeScoresMap  = {};
 
       const attribute = data.modelName || TOXICITY_ATTRIBUTE;
       attributeScores[attribute] = {


### PR DESCRIPTION
This better reflects the recommendation we make to API users, and also reflects the fact that the TOXICITY model doesn't use spans. It will also prevent bugs if we ever decide to return multiple attributes in the response.

I also added a test for specifying a custom attribute name in the config.