### PR TITLE
Removes gapi support from the demo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conversationai/perspectiveapi-authorship-demo",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "license": "Apache-2.0",
   "scripts": {
     "ng": "ng",

--- a/src/app/customizable-demo-form.component.html
+++ b/src/app/customizable-demo-form.component.html
@@ -197,19 +197,6 @@
     </div>
 
     <div class="setting">
-      <mat-slide-toggle [(ngModel)]="useGapi"
-                       (change)="updateApiKey($event); onSettingsChanged()">Use gapi
-      </mat-slide-toggle>
-      <mat-form-field>
-        <input matInput
-               [disabled]="!useGapi"
-               [(ngModel)]="apiKey"
-               (input)="onSettingsChanged()"
-               placeholder="API key"/>
-      </mat-form-field>
-    </div>
-
-    <div class="setting">
       <mat-slide-toggle [(ngModel)]="usePluginEndpoint"
                        (change)="onSettingsChanged()">Use plugin endpoint
       </mat-slide-toggle>

--- a/src/app/customizable-demo-form.component.html
+++ b/src/app/customizable-demo-form.component.html
@@ -52,20 +52,6 @@
       </mat-form-field>
     </div>
 
-    <!-- Configuration for user suggestions. -->
-    <div class="setting">
-      <mat-form-field>
-        <mat-select placeholder="Correction style"
-                   shouldPlaceholderFloat="true"
-                   [(ngModel)]="configuration"
-                   (change)="onSettingsChanged()">
-          <mat-option *ngFor="let configuration of configurations" [value]="configuration">
-            {{ configuration }}
-          </mat-option>
-        </mat-select>
-      </mat-form-field>
-    </div>
-
     <!-- Loading icon/widget style. -->
     <div class="setting">
       <mat-form-field>

--- a/src/app/customizable-demo-form.component.ts
+++ b/src/app/customizable-demo-form.component.ts
@@ -157,14 +157,6 @@ export class CustomizableDemoFormComponent implements OnInit {
   customFeedbackTextScheme: [string, string, string] = DEFAULT_FEEDBACK_TEST_SET;
   useCustomFeedbackText = false;
 
-  /** Configuration (correction UI) options. */
-
-  // Configuration options for the checker that determine the style of the UI
-  // for submitting corrections for bad scores.
-  configurations = [ConfigurationInput.DEMO_SITE];
-  // Configuration selected from the dropdown menu.
-  configuration = 'default';
-
   /** Other settings. */
 
   // Whether to use the endpoint for the plugin.
@@ -209,7 +201,6 @@ export class CustomizableDemoFormComponent implements OnInit {
         const decodedDemoSettings: DemoSettings = JSON.parse(
             decodeURIComponent(params['encodedDemoSettings'] as string));
         console.debug('I see demo settings in the url:', decodedDemoSettings);
-        this.configuration = decodedDemoSettings.configuration;
         if (this.useCustomColorScheme) {
           this.customColorScheme = decodedDemoSettings.gradientColors;
         } else {
@@ -320,7 +311,6 @@ export class CustomizableDemoFormComponent implements OnInit {
    */
   private getDemoSettings(): DemoSettings {
     return JSON.parse(JSON.stringify({
-      configuration: this.configuration,
       gradientColors: this.useCustomColorScheme ?
         this.customColorScheme : this.selectedColorScheme.colors,
       showPercentage: this.showPercentage,

--- a/src/app/customizable-demo-form.component.ts
+++ b/src/app/customizable-demo-form.component.ts
@@ -167,15 +167,10 @@ export class CustomizableDemoFormComponent implements OnInit {
 
   /** Other settings. */
 
-  // Whether to use gapi to make direct API calls instead of going through the
-  // server. Requires an API key.
-  useGapi = false;
   // Whether to use the endpoint for the plugin.
   usePluginEndpoint = false;
   // URL to use for the plugin endpoint (for debugging and local tests).
   pluginEndpointUrl = '';
-  // API key to use when making gapi calls.
-  apiKey = '';
   // Whether to show the percentage next to the feedback text.
   showPercentage = true;
   // Whether to show a "more info" link next to the feedback text.
@@ -256,8 +251,6 @@ export class CustomizableDemoFormComponent implements OnInit {
 
         this.showPercentage = decodedDemoSettings.showPercentage;
         this.showMoreInfoLink = decodedDemoSettings.showMoreInfoLink;
-        this.useGapi = decodedDemoSettings.useGapi;
-        this.apiKey = decodedDemoSettings.apiKey;
         this.hideLoadingIconAfterLoad = decodedDemoSettings.hideLoadingIconAfterLoad;
         this.hideLoadingIconForScoresBelowMinThreshold =
           decodedDemoSettings.hideLoadingIconForScoresBelowMinThreshold;
@@ -275,13 +268,6 @@ export class CustomizableDemoFormComponent implements OnInit {
   /** Resets the custom color scheme UI to use the default color scheme. */
   resetToDefaultColors() {
     this.customColorScheme = DEFAULT_COLORS.slice();
-  }
-
-  /** Clears the API key field when the "Use gapi" option is toggled off. */
-  updateApiKey(event: MatSlideToggleChange) {
-    if (!event.checked) {
-      this.apiKey = '';
-    }
   }
 
   /**
@@ -343,8 +329,6 @@ export class CustomizableDemoFormComponent implements OnInit {
         this.customFeedbackTextScheme : this.selectedFeedbackTextScheme.feedbackTextSet,
       scoreThresholds: this.customizeScoreThresholds ?
         this.scoreThresholds : this.sliderScoreThresholds,
-      useGapi: this.useGapi,
-      apiKey: this.apiKey,
       hideLoadingIconAfterLoad: this.hideLoadingIconAfterLoad,
       hideLoadingIconForScoresBelowMinThreshold:
         this.hideLoadingIconForScoresBelowMinThreshold,

--- a/src/app/modules/convai-checker/convai-checker.component.html
+++ b/src/app/modules/convai-checker/convai-checker.component.html
@@ -13,7 +13,6 @@
     [gradientColors]="demoSettings.gradientColors"
     [scoreThresholds]="demoSettings.scoreThresholds"
     [feedbackText]="demoSettings.feedbackText"
-    [configurationInput]="demoSettings.configuration"
     [showPercentage]="demoSettings.showPercentage"
     [showMoreInfoLink]="demoSettings.usePluginEndpoint ? false : demoSettings.showMoreInfoLink"
     [hasScore]="analyzeCommentResponse !== null"

--- a/src/app/modules/convai-checker/convai-checker.component.spec.ts
+++ b/src/app/modules/convai-checker/convai-checker.component.spec.ts
@@ -508,25 +508,6 @@ describe('Convai checker test', () => {
 
   }));
 
-  it('should default to demo configuration when an invalid configuration is specified', async(() => {
-    const fixture =
-      TestBed.createComponent(test_components.ConvaiCheckerCustomDemoSettingsComponent);
-
-    const demoSettings = getCopyOfDefaultDemoSettings();
-    demoSettings.configuration = 'foo';
-    fixture.componentInstance.setDemoSettings(demoSettings);
-
-    fixture.detectChanges();
-
-    const checker = fixture.componentInstance.checker;
-
-    expect(checker.serverUrl).toEqual('test-url');
-    expect(checker.inputId).toEqual('checkerTextarea');
-    expect(checker.statusWidget.configuration).toEqual(
-      checker.statusWidget.configurationEnum.DEMO_SITE);
-
-  }));
-
   it('should show an error if no textarea id is specified', async(() => {
     const fixture = TestBed.createComponent(test_components.ConvaiCheckerNoInputComponent);
     fixture.detectChanges();

--- a/src/app/modules/convai-checker/convai-checker.component.ts
+++ b/src/app/modules/convai-checker/convai-checker.component.ts
@@ -47,9 +47,6 @@ export interface InputEvent {
 // TODO: Make more of these parameters optional, especially the ones we don't
 // want to expose to users in the public launch.
 export interface DemoSettings {
-  // DEPRECATED. Value is ignored.
-  configuration?: string;
-
   // An array of colors to use as the gradient for the animated loading widget.
   // Minimum length is two, but there is no maximum length.
   gradientColors: string[];

--- a/src/app/modules/convai-checker/convai-checker.component.ts
+++ b/src/app/modules/convai-checker/convai-checker.component.ts
@@ -54,13 +54,6 @@ export interface DemoSettings {
   // Minimum length is two, but there is no maximum length.
   gradientColors: string[];
 
-  // Optional. API key to use when using the Gapi endpoint. Should be empty or
-  // omitted when not using the Gapi endpoint.
-  apiKey?: string;
-
-  // Whether to use the Gapi endpoint.
-  useGapi: boolean;
-
   // Whether to use the plugin endpoint.
   usePluginEndpoint: boolean;
 
@@ -115,8 +108,6 @@ const LOCAL_STORAGE_SESSION_ID_KEY = 'sessionId';
 
 export const DEFAULT_DEMO_SETTINGS = {
   gradientColors: ['#25C1F9', '#7C4DFF', '#D400F9'],
-  apiKey: '',
-  useGapi: false,
   usePluginEndpoint: false,
   showPercentage: true,
   showMoreInfoLink: true,
@@ -142,7 +133,7 @@ const GITHUB_PAGE_LINK =
   styleUrls: ['./convai-checker.component.css'],
   providers: [PerspectiveApiService],
 })
-export class ConvaiCheckerComponent implements OnInit, OnChanges {
+export class ConvaiCheckerComponent implements OnInit {
   @ViewChild(PerspectiveStatusComponent, {static: false})
   statusWidget: PerspectiveStatusComponent;
   @Input() inputId: string;
@@ -176,7 +167,6 @@ export class ConvaiCheckerComponent implements OnInit, OnChanges {
   public feedbackRequestInProgress = false;
   private sessionId: string|null = null;
   private gradientColors: string[] = ['#25C1F9', '#7C4DFF', '#D400F9'];
-  private apiKey: string|undefined;
 
   constructor(
       private elementRef: ElementRef,
@@ -202,30 +192,12 @@ export class ConvaiCheckerComponent implements OnInit, OnChanges {
 
     if (this.demoSettingsJson) {
       this.demoSettings = JSON.parse(this.demoSettingsJson);
-      if (this.demoSettings.apiKey) {
-        this.apiKey = this.demoSettings.apiKey;
-      }
-    }
-
-    if (this.apiKey) {
-      this.analyzeApiService.initGapiClient(this.apiKey);
     }
 
     this.sessionId = window.localStorage.getItem(LOCAL_STORAGE_SESSION_ID_KEY);
     if (this.sessionId === null) {
       this.sessionId = Math.round(Date.now() * Math.random()).toString();
       window.localStorage.setItem(LOCAL_STORAGE_SESSION_ID_KEY, this.sessionId);
-    }
-  }
-
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes['demoSettings']) {
-      if (this.demoSettings && this.demoSettings.apiKey &&
-          this.apiKey !== this.demoSettings.apiKey) {
-        console.debug('Api key changes detected in demoSettings');
-        this.apiKey = this.demoSettings.apiKey;
-        this.analyzeApiService.initGapiClient(this.apiKey);
-      }
     }
   }
 
@@ -336,7 +308,6 @@ export class ConvaiCheckerComponent implements OnInit, OnChanges {
 
     const suggestScoreObservable = this.analyzeApiService.suggestScore(
       suggestCommentScoreData,
-      this.demoSettings.useGapi /* makeDirectApiCall */,
       this.serverUrl
     ).pipe(
       take(1), // Prevents memory leaks.
@@ -403,7 +374,6 @@ export class ConvaiCheckerComponent implements OnInit, OnChanges {
 
     const analyzeCommentObservable = this.analyzeApiService.checkText(
         analyzeCommentData,
-        this.demoSettings.useGapi /* makeDirectApiCall */,
         this.demoSettings.usePluginEndpoint ? this.pluginEndpointUrl : this.serverUrl)
       .pipe(
         take(1), // Prevents memory leaks

--- a/src/index.html
+++ b/src/index.html
@@ -5,7 +5,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500|Roboto+Mono:300,400,500|Roboto+Slab|Source+Serif+Pro" rel="stylesheet">
-    <script src="https://apis.google.com/js/api.js"></script>
   </head>
   <body>
     <div class="demoContainer">

--- a/src/index_with_elements.html
+++ b/src/index_with_elements.html
@@ -5,7 +5,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500|Roboto+Mono:300,400,500|Roboto+Slab|Source+Serif+Pro" rel="stylesheet">
-    <script src="https://apis.google.com/js/api.js"></script>
   </head>
   <body>
     <div class="demoContainer">


### PR DESCRIPTION
The gapi support was added for early experimentation for the plugin, but we have decided to use a different approach because exposing the API key in the client carries security risks.

Also removes the deprecated 'configuration' option from the Demo Settings.