### PR TITLE
Increments the version number since there was an error with the last published version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conversationai/perspectiveapi-authorship-demo",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "license": "Apache-2.0",
   "scripts": {
     "ng": "ng",


### PR DESCRIPTION
The previous npm publish command was run incorrectly, which resulted in issues importing the library. 