### PR TITLE
Deprecates some fields from DemoSettings, plus some general cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conversationai/perspectiveapi-authorship-demo",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "license": "Apache-2.0",
   "scripts": {
     "ng": "ng",
@@ -57,7 +57,6 @@
     "node-emoji": "^1.8.1",
     "rxjs": "6.5.3",
     "toxiclibsjs": "^0.3.3",
-    "twemoji": "^12.1.3",
     "zone.js": "^0.10.2"
   },
   "devDependencies": {

--- a/src/app/customizable-demo-form.component.html
+++ b/src/app/customizable-demo-form.component.html
@@ -149,14 +149,6 @@
 
     <!-- Other settings -->
     <div class="setting">
-      <mat-slide-toggle [(ngModel)]="showPercentage" (change)="onSettingsChanged()">Show percentage</mat-slide-toggle>
-    </div>
-
-    <div class="setting">
-      <mat-slide-toggle [(ngModel)]="showMoreInfoLink" (change)="onSettingsChanged()">Show more info link</mat-slide-toggle>
-    </div>
-
-    <div class="setting">
       <mat-slide-toggle [(ngModel)]="showFeedbackForLowScores"
         (change)="onSettingsChanged()">Show feedback for low scores.
       </mat-slide-toggle>
@@ -178,16 +170,6 @@
                [(ngModel)]="pluginEndpointUrl"
                (input)="onSettingsChanged()"
                placeholder="Plugin server URL"/>
-      </mat-form-field>
-    </div>
-
-
-    <div class="setting">
-      <mat-form-field>
-        <input matInput
-               [(ngModel)]="userFeedbackPromptText"
-               (input)="onSettingsChanged()"
-               placeholder="Feedback prompt"/>
       </mat-form-field>
     </div>
 

--- a/src/app/customizable-demo-form.component.ts
+++ b/src/app/customizable-demo-form.component.ts
@@ -23,10 +23,7 @@ import {
   DEFAULT_FEEDBACK_TEXT
 } from './modules/convai-checker/perspective-status.component';
 import {ActivatedRoute, Params, Router} from '@angular/router';
-import emoji from 'node-emoji';
 import * as _ from 'lodash';
-
-const RAISED_EYEBROW_EMOJI = '🤨 ';
 
 /** Settings about the UI state that should be encoded in the URL. */
 export interface UISettings {
@@ -62,7 +59,6 @@ export interface FeedbackTextScheme {
 const TextFeedbackSchemes = {
   DEFAULT_FEEDBACK_TEXT: DEFAULT_FEEDBACK_TEXT,
   PLEASE_REVIEW_FEEDBACK_TEXT: 'Please review before posting.',
-  EMOJI: 'Emoji',
 };
 
 /**
@@ -79,12 +75,6 @@ const PLEASE_REVIEW_FEEDBACK_TEST_SET: [string, string, string] = [
   TextFeedbackSchemes.PLEASE_REVIEW_FEEDBACK_TEXT,
   TextFeedbackSchemes.PLEASE_REVIEW_FEEDBACK_TEXT,
   TextFeedbackSchemes.PLEASE_REVIEW_FEEDBACK_TEXT
-];
-
-const EMOJIES: [string, string, string] = [
-  emoji.emojify(':blush: :smile: :smiley:'),
-  emoji.emojify(RAISED_EYEBROW_EMOJI + ' :neutral_face: :thinking_face:'),
-  emoji.emojify(':cry: :scream: :angry:'),
 ];
 
 function arraysEqual<T>(array1: T[], array2: T[]): boolean {
@@ -139,10 +129,6 @@ export class CustomizableDemoFormComponent implements OnInit {
     {
       name: TextFeedbackSchemes.PLEASE_REVIEW_FEEDBACK_TEXT,
       feedbackTextSet: PLEASE_REVIEW_FEEDBACK_TEST_SET,
-    },
-    {
-      name: TextFeedbackSchemes.EMOJI,
-      feedbackTextSet: EMOJIES
     }
   ];
   // FeedbackTextScheme selected from the dropdown menu.
@@ -157,12 +143,6 @@ export class CustomizableDemoFormComponent implements OnInit {
   usePluginEndpoint = false;
   // URL to use for the plugin endpoint (for debugging and local tests).
   pluginEndpointUrl = '';
-  // Whether to show the percentage next to the feedback text.
-  showPercentage = true;
-  // Whether to show a "more info" link next to the feedback text.
-  showMoreInfoLink = true;
-  // The text to use to prompt users to submit feedback.
-  userFeedbackPromptText = 'Seem wrong?';
   // Whether to show feedback for scores below the neutral threshold.
   showFeedbackForLowScores = true;
   // Whether to show feedback for scores above the neutral threshold and below
@@ -236,11 +216,8 @@ export class CustomizableDemoFormComponent implements OnInit {
           this.sliderValue = (1 - this.sliderScoreNeutralThreshold) * 100;
         }
 
-        this.showPercentage = decodedDemoSettings.showPercentage;
-        this.showMoreInfoLink = decodedDemoSettings.showMoreInfoLink;
         this.showFeedbackForLowScores = decodedDemoSettings.showFeedbackForLowScores;
         this.showFeedbackForNeutralScores = decodedDemoSettings.showFeedbackForNeutralScores;
-        this.userFeedbackPromptText = decodedDemoSettings.userFeedbackPromptText;
         this.selectedLoadingIconStyle = decodedDemoSettings.loadingIconStyle;
       }
     });
@@ -302,12 +279,9 @@ export class CustomizableDemoFormComponent implements OnInit {
    * default.
    */
   private getDemoSettings(): DemoSettings {
-    console.log('selected color scheme', this.selectedColorScheme);
     return JSON.parse(JSON.stringify({
       gradientColors: this.useCustomColorScheme ?
         this.customColorScheme : this.selectedColorScheme.colors,
-      showPercentage: this.showPercentage,
-      showMoreInfoLink: this.showMoreInfoLink,
       feedbackText: this.useCustomFeedbackText ?
         this.customFeedbackTextScheme : this.selectedFeedbackTextScheme.feedbackTextSet,
       neutralScoreThreshold: this.customizeScoreThresholds ?
@@ -316,7 +290,6 @@ export class CustomizableDemoFormComponent implements OnInit {
         this.toxicScoreThreshold : this.sliderScoreToxicThreshold,
       showFeedbackForLowScores: this.showFeedbackForLowScores,
       showFeedbackForNeutralScores: this.showFeedbackForNeutralScores,
-      userFeedbackPromptText: this.userFeedbackPromptText,
       loadingIconStyle: this.selectedLoadingIconStyle,
       communityId: this.communityId,
       usePluginEndpoint: this.usePluginEndpoint,

--- a/src/app/modules/convai-checker/convai-checker.component.html
+++ b/src/app/modules/convai-checker/convai-checker.component.html
@@ -1,31 +1,24 @@
 <div id="checkerContainer">
   <!-- TODO(rachelrosen): merge perspective-status and convai-checker
-       and move a large portion of the convai-checker code to the perspective-api service. 
-
-       TODO: We're disabling the "learn more" link for the plugin while we decide what to
-       allow in terms of link customization. Re-enable if we decide we want to allow
-       users to customize the link destination target.
+       and move a large portion of the convai-checker code to the perspective-api service.
   -->
   <perspective-status
-    [fontSize]="fontSize"
-    [indicatorWidth]="13"
-    [indicatorHeight]="13"
     [gradientColors]="demoSettings.gradientColors"
     [neutralScoreThreshold]="demoSettings.neutralScoreThreshold"
     [toxicScoreThreshold]="demoSettings.toxicScoreThreshold"
     [feedbackText]="demoSettings.feedbackText"
-    [showPercentage]="demoSettings.showPercentage"
-    [showMoreInfoLink]="demoSettings.usePluginEndpoint ? false : demoSettings.showMoreInfoLink"
+    [showMoreInfoLink]="!demoSettings.usePluginEndpoint"
+    [showFeedbackForLowScores]="demoSettings.showFeedbackForLowScores"
+    [showFeedbackForNeutralScores]="demoSettings.showFeedbackForNeutralScores"
+    [loadingIconStyle]="demoSettings.loadingIconStyle"
+    [hasLocalAssets]="!demoSettings.usePluginEndpoint"
+
     [hasScore]="analyzeCommentResponse !== null"
     [canAcceptFeedback]="canAcceptFeedback"
     [feedbackRequestInProgress]="feedbackRequestInProgress"
     [initializeErrorMessage]="initializeErrorMessage"
     [analyzeErrorMessage]="analyzeErrorMessage"
-    [userFeedbackPromptText]="demoSettings.userFeedbackPromptText"
-    [showFeedbackForLowScores]="demoSettings.showFeedbackForLowScores"
-    [showFeedbackForNeutralScores]="demoSettings.showFeedbackForNeutralScores"
-    [loadingIconStyle]="demoSettings.loadingIconStyle"
-    [hasLocalAssets]="!demoSettings.usePluginEndpoint"
+
     (commentFeedbackSubmitted)="onCommentFeedbackReceived($event)"
     (scoreChangeAnimationCompleted)="handleScoreChangeAnimationCompleted()"
     (modelInfoLinkClicked)="handleModelInfoLinkClicked()">

--- a/src/app/modules/convai-checker/convai-checker.component.spec.ts
+++ b/src/app/modules/convai-checker/convai-checker.component.spec.ts
@@ -203,7 +203,7 @@ async function verifyLayerTransitionsWorkForDemoSiteConfig(
 
   const layer1TextElements = [
     'perceived as toxic',
-    'SEEM WRONG?'
+    'DISAGREE?'
   ];
   const layer1VisibleElementIds = ['layer1', 'seemWrongButtonDemoConfig'];
   const layer1HiddenElementIds = ['layer2', 'layer3'];
@@ -462,17 +462,7 @@ describe('Convai checker test', () => {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = ORIGINAL_TIMEOUT;
   });
 
-  it('should recognize inputs from attributes', async(() => {
-    const fixture = TestBed.createComponent(
-      test_components.ConvaiCheckerWithAttributeInputComponent);
-    fixture.detectChanges();
-
-    const checker = fixture.componentInstance.checker;
-
-    expect(checker.serverUrl).toEqual('test-url');
-    expect(checker.inputId).toEqual('checkerTextarea');
-    expect(checker.demoSettings.communityId).toEqual('testCommunityId');
-  }));
+  // TODO: Is it possible to add a test for the Angular element use case?
 
   it('should recognize inputs from angular input bindings', async(() => {
     const fixture =
@@ -749,7 +739,7 @@ describe('Convai checker test', () => {
     // Checks that loading has stopped.
     expect(checker.statusWidget.isLoading).toBe(false);
 
-    // Click the 'Seem wrong?' button
+    // Click the 'Disagree?' button
     const seemWrongButton = document.getElementById('seemWrongButtonDemoConfig');
     sendClickEvent(seemWrongButton);
 
@@ -808,7 +798,7 @@ describe('Convai checker test', () => {
     expect(checker.statusWidget.isLoading).toBe(false);
 
     // Seem wrong button should be displayed.
-    expect(fixture.nativeElement.textContent).toContain('Seem wrong?');
+    expect(fixture.nativeElement.textContent).toContain('Disagree?');
 
     // 2) After the first check compconstes, send an event that the
     // textbox has been cleared.
@@ -819,7 +809,7 @@ describe('Convai checker test', () => {
     fixture.detectChanges();
 
     // Sanity check -- seems wrong button should not be displayed.
-    expect(fixture.nativeElement.textContent).not.toContain('Seem wrong?');
+    expect(fixture.nativeElement.textContent).not.toContain('Disagree?');
 
     // 3) Try to leave feedback for the empty string anyway, to make sure it
     // does not go through. This state should not be possible but we

--- a/src/app/modules/convai-checker/convai-checker.component.ts
+++ b/src/app/modules/convai-checker/convai-checker.component.ts
@@ -54,12 +54,6 @@ export interface DemoSettings {
   // Whether to use the plugin endpoint.
   usePluginEndpoint: boolean;
 
-  // Whether to show the model score in the UI.
-  showPercentage: boolean;
-
-  // Determines whether “More info” link is visible.
-  showMoreInfoLink: boolean;
-
   // Three feedback messages to display to the user. These can contain emoji
   // unicode. This must be length 3.
   feedbackText: [string, string, string];
@@ -81,9 +75,6 @@ export interface DemoSettings {
   // The loading icon style. See perspective-status.LoadingIconStyle for
   // options.
   loadingIconStyle: string;
-
-  // The string to use to prompt users to submit feedback.
-  userFeedbackPromptText: string;
 
   // An id for the community using the checker.
   communityId?: string;
@@ -129,7 +120,6 @@ export class ConvaiCheckerComponent implements OnInit {
   statusWidget: PerspectiveStatusComponent;
   @Input() inputId: string;
   @Input() serverUrl: string;
-  @Input() fontSize = 12;
   @Input() demoSettings: DemoSettings = DEFAULT_DEMO_SETTINGS;
   // A JSON string representation of the DemoSettings. Expected to be static
   // over the course of the component's lifecycle, and should only be used from
@@ -157,18 +147,11 @@ export class ConvaiCheckerComponent implements OnInit {
   public canAcceptFeedback = false;
   public feedbackRequestInProgress = false;
   private sessionId: string|null = null;
-  private gradientColors: string[] = ['#25C1F9', '#7C4DFF', '#D400F9'];
 
   constructor(
       private elementRef: ElementRef,
       private analyzeApiService: PerspectiveApiService
   ) {
-    // Extracts attribute fields from the element declaration. This
-    // covers the case where this component is used as a root level
-    // component outside an angular component tree and we cannot get
-    // these values from data bindings.
-    this.inputId = this.elementRef.nativeElement.getAttribute('inputId');
-
     // Default to '' to use same server as whatever's serving the webapp.
     this.serverUrl =
       this.elementRef.nativeElement.getAttribute('serverUrl') || '';
@@ -327,9 +310,8 @@ export class ConvaiCheckerComponent implements OnInit {
     // Look at detailed API error messages for more meaningful error to return.
     try {
       for (const api_err of error.error.errors) {
-        // TODO(jetpack): a small hack to handle the language detection failure
-        // case. we should instead change the API to return documented, typeful
-        // errors.
+        // TODO: a small hack to handle the language detection failure case.
+        // Update this to use the API's new typeful errors.
         if (api_err.message.includes('does not support request languages')) {
           msg = 'We don\'t yet support that language, but we\'re working on it!';
           break;

--- a/src/app/modules/convai-checker/perspective-status.component.html
+++ b/src/app/modules/convai-checker/perspective-status.component.html
@@ -63,7 +63,7 @@
                tabindex=0
                role="status"
                [attr.aria-hidden]="!showScore || isPlayingLoadingAnimation || isPlayingFadeDetailsAnimation">
-            <span id="feedbackText" [innerHTML]="parseEmojis(getFeedbackTextForScore(score))"></span><span *ngIf="showPercentage" id="percentage">({{score.toFixed(2)}})</span><span
+            <span id="feedbackText">{{getFeedbackTextForScore(score)}}</span><span
                *ngIf="showMoreInfoLink"
                class="link"
                role="link"

--- a/src/app/modules/convai-checker/test-components.ts
+++ b/src/app/modules/convai-checker/test-components.ts
@@ -65,29 +65,6 @@ export class ConvaiCheckerMissingInputIdComponent {
   serverUrl = 'test-url';
 }
 
-@Component({
-  selector: 'test-comp-attribute-input',
-  template: `
-        <convai-checker
-           id="checker"
-           inputId="checkerTextarea"
-           [demoSettings]="demoSettings"
-           serverUrl="test-url">
-          Loading...
-        </convai-checker>
-        <textarea class="checkerInputBox"
-                  id="checkerTextarea"
-                  placeholder="type something here and see how the dot above reacts.">
-        </textarea>`,
-})
-export class ConvaiCheckerWithAttributeInputComponent {
-  @ViewChild(ConvaiCheckerComponent, {static: false}) checker: ConvaiCheckerComponent;
-  demoSettings = JSON.parse(JSON.stringify(DEFAULT_DEMO_SETTINGS));
-  constructor() {
-    this.demoSettings.communityId = 'testCommunityId';
-  }
-}
-
 /** Test component with customizable DemoSettings. */
 @Component({
   selector: 'checker-custom-demo-settings',
@@ -161,7 +138,6 @@ export class ConvaiCheckerJsonDemoSettingsComponent implements OnInit {
     ConvaiCheckerNoInputComponent,
     ConvaiCheckerNoDemoSettingsComponent,
     ConvaiCheckerMissingInputIdComponent,
-    ConvaiCheckerWithAttributeInputComponent,
     ConvaiCheckerCustomDemoSettingsComponent,
     ConvaiCheckerJsonDemoSettingsComponent
   ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -3942,7 +3942,7 @@ fs-extra@^7.0.1:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^8.0.0, fs-extra@^8.0.1:
+fs-extra@^8.0.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
   integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
@@ -5337,15 +5337,6 @@ jsonfile@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
   integrity sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
-  optionalDependencies:
-    graceful-fs "^4.1.6"
-
-jsonfile@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-5.0.0.tgz#e6b718f73da420d612823996fdf14a03f6ff6922"
-  integrity sha512-NQRZ5CRo74MhMMC3/3r5g2k4fjodJ/wh8MxjFbCViWKFjxrnudWSY5vomh+23ZaXzAS7J3fBZIR2dV6WbmfM0w==
-  dependencies:
-    universalify "^0.1.2"
   optionalDependencies:
     graceful-fs "^4.1.6"
 
@@ -8759,21 +8750,6 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
 
-twemoji-parser@12.1.0:
-  version "12.1.0"
-  resolved "https://registry.yarnpkg.com/twemoji-parser/-/twemoji-parser-12.1.0.tgz#018fb2a67f4747d9decfbf2bb4372995fc568997"
-  integrity sha512-jaHYltumP/E8nR+YzRrY753j9dEpL3zH8+pDXgf9h/10wHeW/9IIjs6mZ1Z/Syh8rIaOQObev1BAX/AinFmuOg==
-
-twemoji@^12.1.3:
-  version "12.1.3"
-  resolved "https://registry.yarnpkg.com/twemoji/-/twemoji-12.1.3.tgz#4bebee358c7c44c4278d2badf320bc9e1d057f1d"
-  integrity sha512-Y5mC7vVovHZvCzdXDepJaU6FHPd7PaW6ZTBMWy9sGYafLBn1x0h2T6aGA3cpnz3WgWWg2QI+3D+9Rn4Z/ViitQ==
-  dependencies:
-    fs-extra "^8.0.1"
-    jsonfile "^5.0.0"
-    twemoji-parser "12.1.0"
-    universalify "^0.1.2"
-
 type-fest@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.3.1.tgz#63d00d204e059474fe5e1b7c011112bbd1dc29e1"
@@ -8883,7 +8859,7 @@ universal-analytics@^0.4.20:
     request "^2.88.0"
     uuid "^3.0.0"
 
-universalify@^0.1.0, universalify@^0.1.2:
+universalify@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==


### PR DESCRIPTION
From DemoSettings, we're removing the fields showPercentage,	showMoreInfoLink, and userFeedbackPromptText. Whether to show the score percentage is now determined by a placeholder in the feedback text string (x%), showing the more info link is disabled for the plugin, and we're using a constant non-customizable string for the feedback prompt. 

This change also does cleanup such as removing unused variables, updating TODOs, and removing the use of the twemoji library, which we weren't really utilizing.