### PR TITLE
Fixes loading icon visibility bug + change to element height

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conversationai/perspectiveapi-authorship-demo",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "license": "Apache-2.0",
   "scripts": {
     "ng": "ng",

--- a/src/app/modules/convai-checker/convai-checker.component.spec.ts
+++ b/src/app/modules/convai-checker/convai-checker.component.spec.ts
@@ -86,6 +86,10 @@ const getIsElementWithIdVisible = function(id: string): boolean {
       && getElementOpacity(id) > 0;
 };
 
+const getElementExists = function(id: string): boolean {
+  return document.getElementById(id) !== null;
+};
+
 const getElementXTranslation = function(id: string): number|null {
   const element = document.getElementById(id);
   if (!element) {
@@ -150,9 +154,9 @@ function verifyCircleSquareDiamondWidgetVisible() {
   // Checks visibility of the loading icons. The circle/square/diamond
   // loading icon should be visible, and the emoji one should not.
   const circleSquareDiamondWidgetVisible =
-   getIsElementWithIdVisible('circleSquareDiamondWidget');
+    getIsElementWithIdVisible('circleSquareDiamondWidget');
   const emojiWidgetVisible =
-   getIsElementWithIdVisible('emojiStatusWidget');
+    getIsElementWithIdVisible('emojiStatusWidget');
   expect(circleSquareDiamondWidgetVisible).toBe(true);
   expect(emojiWidgetVisible).toBe(false);
 }
@@ -1779,4 +1783,59 @@ describe('Convai checker test', () => {
     expect(checker.demoSettings).toEqual(expectedDemoSettings);
     expect(checker.demoSettings).not.toEqual(getCopyOfDefaultDemoSettings());
   }));
+
+  it('Test correct visibility of loading icon after loadingIconStyle change', async() => {
+    const fixture = TestBed.createComponent(test_components.ConvaiCheckerCustomDemoSettingsComponent);
+    fixture.detectChanges();
+    const checker = fixture.componentInstance.checker;
+
+    // Change back and forth without any visibility restrictions. Icons for the
+    // respective icon type should be visible.
+    verifyCircleSquareDiamondWidgetVisible();
+
+    const demoSettings = getCopyOfDefaultDemoSettings();
+    demoSettings.loadingIconStyle = LoadingIconStyle.EMOJI;
+    fixture.componentInstance.setDemoSettings(demoSettings);
+    fixture.detectChanges();
+    await checker.statusWidget.animationsDone.pipe(take(1)).toPromise();
+    fixture.detectChanges();
+    verifyEmojiWidgetVisible();
+
+    demoSettings.loadingIconStyle = LoadingIconStyle.CIRCLE_SQUARE_DIAMOND;
+    fixture.componentInstance.setDemoSettings(demoSettings);
+    fixture.detectChanges();
+    await checker.statusWidget.animationsDone.pipe(take(1)).toPromise();
+    fixture.detectChanges();
+    verifyCircleSquareDiamondWidgetVisible();
+
+    // Change back and forth while hiding icon for low scores (default score is
+    // 0). Icons for the respective icon type should exist in the DOM, but
+    // should be hidden.
+    demoSettings.showFeedbackForLowScores = false;
+    fixture.componentInstance.setDemoSettings(demoSettings);
+    fixture.detectChanges();
+    await checker.statusWidget.animationsDone.pipe(take(1)).toPromise();
+    fixture.detectChanges();
+    expect(getElementExists('circleSquareDiamondWidget')).toBe(true);
+    expect(getIsElementWithIdVisible('circleSquareDiamondWidget')).toBe(false);
+    expect(getElementExists('emojiStatusWidget')).toBe(false);
+
+    demoSettings.loadingIconStyle = LoadingIconStyle.EMOJI;
+    fixture.componentInstance.setDemoSettings(demoSettings);
+    fixture.detectChanges();
+    await checker.statusWidget.animationsDone.pipe(take(1)).toPromise();
+    fixture.detectChanges();
+    expect(getElementExists('emojiStatusWidget')).toBe(true);
+    expect(getIsElementWithIdVisible('emojiStatusWidget')).toBe(false);
+    expect(getElementExists('circleSquareDiamondWidget')).toBe(false);
+
+    demoSettings.loadingIconStyle = LoadingIconStyle.CIRCLE_SQUARE_DIAMOND;
+    fixture.componentInstance.setDemoSettings(demoSettings);
+    fixture.detectChanges();
+    await checker.statusWidget.animationsDone.pipe(take(1)).toPromise();
+    fixture.detectChanges();
+    expect(getElementExists('circleSquareDiamondWidget')).toBe(true);
+    expect(getIsElementWithIdVisible('circleSquareDiamondWidget')).toBe(false);
+    expect(getElementExists('emojiStatusWidget')).toBe(false);
+  });
 });

--- a/src/app/modules/convai-checker/perspective-status.component.css
+++ b/src/app/modules/convai-checker/perspective-status.component.css
@@ -175,7 +175,7 @@
 }
 
 #widgetContainer {
-  height: 50px;
+  height: 36px;
 }
 
 .error {

--- a/src/app/modules/convai-checker/perspective-status.component.ts
+++ b/src/app/modules/convai-checker/perspective-status.component.ts
@@ -365,10 +365,11 @@ export class PerspectiveStatusComponent implements OnChanges, OnInit, AfterViewI
           this.updateWidgetElement();
           // If the previous loading icon was already hidden, we should update
           // the position of the new one to match, so transition animations
-          // work correctly.
+          // work correctly. We also update the opacity.
           if (this.shouldHideStatusWidget) {
             this.widgetElement.style.transform =
               'matrix(1,0,0,1,' + (-1 * (this.indicatorWidth + WIDGET_PADDING_PX + WIDGET_RIGHT_MARGIN_PX)) + ',0)';
+            this.widgetElement.style.opacity = '0';
           }
           console.debug('Setting loadingIconStyleChanged to false');
           this.loadingIconStyleChanged = false;
@@ -944,6 +945,7 @@ export class PerspectiveStatusComponent implements OnChanges, OnInit, AfterViewI
     } else {
       emojiType = Emoji.SMILE;
     }
+
     const emojiElementToShow = this.getEmojiElementFromEmojiType(emojiType);
     const showEmojiTimeline = new TimelineMax({
       onStart: () => {
@@ -968,6 +970,7 @@ export class PerspectiveStatusComponent implements OnChanges, OnInit, AfterViewI
       resetBackgroundColorAnimation,
       this.getToFullScaleBounceAnimation(EMOJI_BOUNCE_IN_TIME_SECONDS),
       this.getChangeOpacityAnimation(emojiElementToShow, FADE_EMOJI_TIME_SECONDS, 1)]);
+
     return showEmojiTimeline;
   }
 


### PR DESCRIPTION
Fixes the bug where changing the loading icon state from shape to emoji while the icon was hidden caused it to reappear, and adds a test for this. Also reduces the height of the widget. It can now accommodate a 2-line feedback message, but not a 3-line one.