### PR TITLE
Adds a LoadingIconStyle.NONE option to the demo. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conversationai/perspectiveapi-authorship-demo",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "license": "Apache-2.0",
   "scripts": {
     "ng": "ng",

--- a/src/app/customizable-demo-form.component.ts
+++ b/src/app/customizable-demo-form.component.ts
@@ -116,8 +116,11 @@ export class CustomizableDemoFormComponent implements OnInit {
   customizeScoreThresholds = false;
 
   /** Loading icon style options. */
-  loadingIconStyles =
-    [LoadingIconStyle.CIRCLE_SQUARE_DIAMOND, LoadingIconStyle.EMOJI];
+  loadingIconStyles = [
+    LoadingIconStyle.CIRCLE_SQUARE_DIAMOND,
+    LoadingIconStyle.EMOJI,
+    LoadingIconStyle.NONE
+  ];
   selectedLoadingIconStyle = LoadingIconStyle.CIRCLE_SQUARE_DIAMOND;
 
   /** Feedback text options. */

--- a/src/app/modules/convai-checker/perspective-status.component.html
+++ b/src/app/modules/convai-checker/perspective-status.component.html
@@ -12,7 +12,8 @@
        cannot be found when the component is initializing if their display
        conditions are not met. -->
   <div id="animationContainer">
-    <div *ngIf="loadingIconStyle === loadingIconStyleConst.CIRCLE_SQUARE_DIAMOND"
+    <div *ngIf="loadingIconStyle === loadingIconStyleConst.CIRCLE_SQUARE_DIAMOND
+                || loadingIconStyle === loadingIconStyleConst.NONE"
          id="circleSquareDiamondLoadingIconContainer">
       <div
            #circleSquareDiamondWidget
@@ -20,8 +21,9 @@
            class="dot"
            [style.width]="indicatorWidth"
            [style.height]="indicatorHeight"
-           [hidden]="shouldHideStatusWidget"
-           [attr.aria-hidden]="shouldHideStatusWidget || isPlayingShowOrHideLoadingWidgetAnimation"
+           [hidden]="shouldHideStatusWidget || loadingIconStyle === loadingIconStyleConst.NONE"
+           [attr.aria-hidden]="shouldHideStatusWidget || isPlayingShowOrHideLoadingWidgetAnimation
+                               || loadingIconStyle === loadingIconStyleConst.NONE"
            [attr.aria-label]="getAnimationA11yLabel(loadingIconStyle, isPlayingLoadingAnimation)"
            tabindex=0>
       </div>
@@ -68,7 +70,7 @@
                [style.fontSize]="fontSize"
                tabindex=0
                role="status"
-               [attr.aria-hidden]="!showScore || isPlayingLoadingAnimation || isPlayingFadeDetailsAnimation">
+               [attr.aria-hidden]="isPlayingLoadingAnimation || isPlayingFadeDetailsAnimation">
             <span id="feedbackText">{{getFeedbackTextForScore(score)}}</span>
           </div>
 
@@ -89,7 +91,7 @@
                role="button"
                class="seemWrongButton purpleButton noBorderButton"
                [style.fontSize]="fontSize"
-               [disabled]="!showScore || isPlayingLoadingAnimation || layersAnimating"
+               [disabled]="isPlayingLoadingAnimation || layersAnimating"
                (click)="feedbackContainerClicked()"
                tabindex=0
                [ngStyle]="{'font-family': fontFamily || '\'Roboto\', sans-serif'}">
@@ -133,7 +135,7 @@
                 class="yesNoButton purpleButton noBorderButton"
                 role="button"
                 [style.fontSize]="fontSize"
-                [disabled]="!showScore || isPlayingLoadingAnimation || layersAnimating"
+                [disabled]="isPlayingLoadingAnimation || layersAnimating"
                 (click)="submitFeedback(true)"
                 tabindex=0
                 [ngStyle]="{'font-family': fontFamily || '\'Roboto\', sans-serif'}">
@@ -146,7 +148,7 @@
                 class="yesNoButton purpleButton noBorderButton"
                 role="button"
                 [style.fontSize]="fontSize"
-                [disabled]="!showScore || isPlayingLoadingAnimation || layersAnimating"
+                [disabled]="isPlayingLoadingAnimation || layersAnimating"
                 (click)="submitFeedback(false)"
                 tabindex=0
                 [ngStyle]="{'font-family': fontFamily || '\'Roboto\', sans-serif'}">

--- a/src/app/modules/convai-checker/perspective-status.component.ts
+++ b/src/app/modules/convai-checker/perspective-status.component.ts
@@ -367,11 +367,9 @@ export class PerspectiveStatusComponent implements OnChanges, OnInit, AfterViewI
           // the position of the new one to match, so transition animations
           // work correctly. We also update the opacity.
           if (this.shouldHideStatusWidget) {
-            if (this.widgetElement !== null) {
-              this.widgetElement.style.transform =
-                'matrix(1,0,0,1,' + (-1 * (this.indicatorWidth + WIDGET_PADDING_PX + WIDGET_RIGHT_MARGIN_PX)) + ',0)';
-              this.widgetElement.style.opacity = '0';
-            }
+            this.widgetElement.style.transform =
+              'matrix(1,0,0,1,' + (-1 * (this.indicatorWidth + WIDGET_PADDING_PX + WIDGET_RIGHT_MARGIN_PX)) + ',0)';
+            this.widgetElement.style.opacity = '0';
           }
           console.debug('Setting loadingIconStyleChanged to false');
           this.loadingIconStyleChanged = false;
@@ -917,6 +915,10 @@ export class PerspectiveStatusComponent implements OnChanges, OnInit, AfterViewI
         }
         this.isLoading = loading;
         if (!this.isPlayingLoadingAnimation) {
+          // Treat the LoadingIconStyle.NONE case the same as the
+          // CIRCLE_SQUARE_DIAMOND case for the purposes of animation sequences;
+          // the difference will be that the widget will be hidden, but the
+          // widget state and logic are the same.
           if (this.loadingIconStyle === LoadingIconStyle.CIRCLE_SQUARE_DIAMOND
               || this.loadingIconStyle === LoadingIconStyle.NONE) {
             this.setLoadingForDefaultWidget();


### PR DESCRIPTION
This behaves the same as the deprecated "alwaysHideLoadingIcon" parameter in the DemoSettings, but now can be set as a LoadingIconStyle option. Logic-wise, this change considers the NONE state to be equivalent to the CIRCLE_SQUARE_DIAMOND option but with the icon hidden. This is simpler than the alternative of rewriting a new template entry for the hidden icon because it allows for hiding and showing animations, maintaining a widget element in the DOM (which is stateful), and not creating new loading animations for this hidden state preserves existing logic built into the animations for showing and hiding the text during and after loading, reducing repeated code and the chance for introducing bugs.

This change also does some small cleanup on the code in perspective-status.