### PR TITLE
Updates to checker behavior when the model changes based on team feedback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conversationai/perspectiveapi-authorship-demo",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "license": "Apache-2.0",
   "scripts": {
     "ng": "ng",

--- a/src/app/modules/convai-checker/convai-checker.component.html
+++ b/src/app/modules/convai-checker/convai-checker.component.html
@@ -13,6 +13,7 @@
     [hasLocalAssets]="!demoSettings.usePluginEndpoint"
     [fontFamily]="demoSettings.fontFamily"
 
+    [modelDescription]="modelDescription"
     [hasScore]="analyzeCommentResponse !== null"
     [canAcceptFeedback]="canAcceptFeedback"
     [feedbackRequestInProgress]="feedbackRequestInProgress"

--- a/src/app/modules/convai-checker/perspective-status.component.html
+++ b/src/app/modules/convai-checker/perspective-status.component.html
@@ -118,7 +118,7 @@
                     tabindex=0
                     (keyup.enter)="notifyModelInfoLinkClicked()"
                     (keyup.space)="notifyModelInfoLinkClicked()"
-                    (click)="notifyModelInfoLinkClicked()">toxic</span>?
+                    (click)="notifyModelInfoLinkClicked()">{{modelDescription}}</span>?
             </span>
           </div>
         </div> <!-- End configuration DEMO_SITE -->

--- a/src/app/modules/convai-checker/perspective-status.component.ts
+++ b/src/app/modules/convai-checker/perspective-status.component.ts
@@ -108,6 +108,7 @@ export class PerspectiveStatusComponent implements OnChanges, OnInit, AfterViewI
   @Input() feedbackRequestSubmitted = false;
   @Input() feedbackRequestError = false;
   @Input() initializeErrorMessage: string;
+  @Input() modelDescription = '';
   @Input() feedbackText: [string, string, string] = [
      DEFAULT_FEEDBACK_TEXT,
      DEFAULT_FEEDBACK_TEXT,
@@ -307,29 +308,31 @@ export class PerspectiveStatusComponent implements OnChanges, OnInit, AfterViewI
         }
       });
 
-      if (this.isLoading) {
-        // Animations to run after any pending loading finishes.
-        this.pendingPostLoadingStateChangeAnimations = new TimelineMax({
-          onStart: () => {
-            this.ngZone.run(() => {
-              this.isPlayingPostLoadingStateChangeAnimations = true;
-              console.debug('Started postLoadingStateChangeAnimations');
-            });
-          },
-          onComplete: () => {
-            this.ngZone.run(() => {
-              this.isPlayingPostLoadingStateChangeAnimations = false;
-              console.debug('Completing postLoadingStateChangeAnimations');
-            });
-          }
-        });
-      } else {
-        this.pendingPostLoadingStateChangeAnimations = null;
-      }
-
       // Run in a Promise resolve statement so we don't get an
       // ExpressionChangedAfterItHasBeenCheckedError.
       Promise.resolve().then(() => {
+        // Between the previous block of code and the Promise.resolve(), the
+        // state of isLoading can change. Define the animations here to avoid
+        // assinging to the wrong animation if that happens.
+        if (this.isLoading) {
+          // Animations to run after any pending loading finishes.
+          this.pendingPostLoadingStateChangeAnimations = new TimelineMax({
+            onStart: () => {
+              this.ngZone.run(() => {
+                this.isPlayingPostLoadingStateChangeAnimations = true;
+                console.debug('Started postLoadingStateChangeAnimations');
+              });
+            },
+            onComplete: () => {
+              this.ngZone.run(() => {
+                this.isPlayingPostLoadingStateChangeAnimations = false;
+                console.debug('Completing postLoadingStateChangeAnimations');
+              });
+            }
+          });
+        } else {
+          this.pendingPostLoadingStateChangeAnimations = null;
+        }
         if (this.gradientColorsChanged) {
           this.gradientColorsChanged = false;
           if (this.loadingIconStyle === LoadingIconStyle.CIRCLE_SQUARE_DIAMOND) {


### PR DESCRIPTION
1.Changes the user feedback prompt text to reflect the different model names (e.g. "Is this toxic/obscene/etc?)
2. Sends a new check request when the user changes the model.