### PR TITLE
Fixes the error while generating the plugin.js code

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build:dev": "npm run setup && ng build --project perspectiveapi-authorship-demo",
     "build:dev-customElements": "npm run setup && ng build --project customCheckerElements",
     "build:prod": "npm run setup && ng build --project perspectiveapi-authorship-demo --prod --extract-css=false --build-optimizer=false",
-    "build:prod-customElements": "npm run setup && ng build --project customCheckerElements --prod --extract-css=false --build-optimizer=false",
+    "build:prod-customElements": "npm run setup && ng build --project customCheckerElements --prod --extract-css=false",
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "@webcomponents/custom-elements": "^1.0.6",
     "codelyzer": "5.1.2",
     "concurrently": "^5.0.0",
-    "core-js": "^3.2.1",
     "d3-color": "^1.0.3",
     "d3-interpolate": "^1.1.4",
     "gsap": "^2.1.3",
@@ -54,13 +53,12 @@
     "lodash": "^4.17.4",
     "ng-recaptcha": "^5.0.0",
     "ngx-color-picker": "^8.2.0",
-    "node-emoji": "^1.8.1",
-    "rxjs": "6.5.3",
+    "rxjs": "6.5.4",
     "toxiclibsjs": "^0.3.3",
     "zone.js": "^0.10.2"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "~0.803.8",
+    "@angular-devkit/build-angular": "~0.803.24",
     "@angular/animations": "^8.2.9",
     "@angular/cdk": "^8.2.2",
     "@angular/cli": "~8.3.8",

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -41,8 +41,8 @@
 
 
 /** Evergreen browsers require these. **/
-import 'core-js/es/reflect';
-import 'core-js/es/reflect';
+//import 'core-js/es/reflect';
+//import 'core-js/es/reflect';
 
 
 /** ALL Firefox browsers require the following to support `@angular/animation`. **/
@@ -54,13 +54,7 @@ import 'core-js/es/reflect';
  * Zone JS is required by Angular itself.
  */
 
-(window as any).__zone_symbol__forceDuplicateZoneCheck = false;
-
-//declare var System;
-//if (!window['Zone']) { // Only import if zone.js isn't already loaded.
-//  System.import('zone.js/dist/zone');  // Included with Angular CLI.
-//}
-//import 'zone.js/dist/zone';  // Included with Angular CLI.
+import 'zone.js/dist/zone';  // Included with Angular CLI.
 
 /** Hammerjs is required for Angular material components. */
 import 'hammerjs/hammer';

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -41,8 +41,8 @@
 
 
 /** Evergreen browsers require these. **/
-//import 'core-js/es/reflect';
-//import 'core-js/es/reflect';
+// import 'core-js/es/reflect';
+// import 'core-js/es/reflect';
 
 
 /** ALL Firefox browsers require the following to support `@angular/animation`. **/

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -39,16 +39,8 @@
 /** IE10 and IE11 requires the following to support `@angular/animation`. */
 // import 'web-animations-js';  // Run `npm install --save web-animations-js`.
 
-
-/** Evergreen browsers require these. **/
-// import 'core-js/es/reflect';
-// import 'core-js/es/reflect';
-
-
 /** ALL Firefox browsers require the following to support `@angular/animation`. **/
 // import 'web-animations-js';  // Run `npm install --save web-animations-js`.
-
-
 
 /***************************************************************************************************
  * Zone JS is required by Angular itself.

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -53,7 +53,14 @@ import 'core-js/es/reflect';
 /***************************************************************************************************
  * Zone JS is required by Angular itself.
  */
-import 'zone.js/dist/zone';  // Included with Angular CLI.
+
+(window as any).__zone_symbol__forceDuplicateZoneCheck = false;
+
+//declare var System;
+//if (!window['Zone']) { // Only import if zone.js isn't already loaded.
+//  System.import('zone.js/dist/zone');  // Included with Angular CLI.
+//}
+//import 'zone.js/dist/zone';  // Included with Angular CLI.
 
 /** Hammerjs is required for Angular material components. */
 import 'hammerjs/hammer';


### PR DESCRIPTION
The source of the error was with the older version of @angular-devkit/build-angular, which was overwriting Promise after zone.js was loaded.

Also cleans up unused libraries and removes core-js, since Angular CLI pulls that in now.